### PR TITLE
Add a new bill identifier field to the vote event schema.

### DIFF
--- a/openstates/scrape/schemas/vote_event.py
+++ b/openstates/scrape/schemas/vote_event.py
@@ -18,6 +18,7 @@ schema = {
         "legislative_session": {"type": "string", "minLength": 1},
         "bill": {"type": ["string", "null"], "minLength": 1},
         "bill_action": {"type": ["string", "null"], "minLength": 1},
+        "bill_identifier": {"type": "string"},
         "votes": {
             "items": {
                 "type": "object",

--- a/openstates/scrape/vote_event.py
+++ b/openstates/scrape/vote_event.py
@@ -56,12 +56,14 @@ class VoteEvent(BaseModel, SourceMixin):
     def set_bill(self, bill_or_identifier, *, chamber=None):
         if not bill_or_identifier:
             self.bill = None
+            self.bill_identifier = ""
         elif isinstance(bill_or_identifier, Bill):
             if chamber:
                 raise ScrapeValueError(
                     "set_bill takes no arguments when using a `Bill` object"
                 )
             self.bill = bill_or_identifier._id
+            self.bill_identifier = bill_or_identifier.identifier
         else:
             if chamber is None:
                 chamber = "legislature"
@@ -71,6 +73,7 @@ class VoteEvent(BaseModel, SourceMixin):
                 "legislative_session__identifier": self.legislative_session,
             }
             self.bill = _make_pseudo_id(**kwargs)
+            self.bill_identifier = bill_or_identifier
 
     def vote(self, option, voter, *, note=""):
         self.votes.append(


### PR DESCRIPTION
Howdy,

This PR adds a new `bill_identifier` field to the vote event schema. This field is populated with:
- An empty string if `bill_or_identifier` is not present
- The value of `bill_or_identifier.identifier` if `bill_or_identifier` is an instance of `Bill`
- The value of `bill_or_identifier` itself

We use this value in [our modified branch](https://github.com/opencivicdata/pupa/pull/315/files#diff-c480a0b45aad14ae8de457901d6fabe6) to make bill associations. I figured a new field might be cleaner than adding another environment variable.

Please let me know if you have any concerns or questions. Thanks!