### PR TITLE
Remove new vote event key before being processed by Django models.

### DIFF
--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -213,6 +213,8 @@ class BaseImporter(object):
 
         for data in dicts:
             json_id = data.pop("_id")
+            if self._type == "vote_event":
+                data.pop("bill_identifier", None)
 
             # map duplicates (using omnihash to tell if json dicts are identical-ish)
             objhash = omnihash(data)
@@ -252,6 +254,8 @@ class BaseImporter(object):
 
         # remove the JSON _id (may still be there if called directly)
         data.pop("_id", None)
+        if self._type == "vote_event":
+            data.pop("bill_identifier", None)
 
         # add fields/etc.
         data = self.apply_transformers(data)


### PR DESCRIPTION
Hi again,

This PR is a follow-up to the failing tests mentioned here https://github.com/openstates/openstates-core/pull/12#issuecomment-618629248. I think I just needed to `pop` off the new `bill_identifier` field from vote event data before being processed by Django models.

I passed all tests locally; however, let me know if I missed anything or if you have any feedback. Thanks!