### PR TITLE
Small changes for local testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .coverage
 .python-version
 .tox
+.venv/
 __pycache__
 _cache/
 _data/

--- a/openstates/test_settings.py
+++ b/openstates/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 # django settings for tests
 SECRET_KEY = "test"
 INSTALLED_APPS = (
@@ -11,7 +13,7 @@ DATABASES = {
         "NAME": "test",
         "USER": "test",
         "PASSWORD": "test",
-        "HOST": "localhost",
+        "HOST": os.environ.get("DB_HOST", "localhost"),
     }
 }
 MIDDLEWARE_CLASSES = ()

--- a/openstates/test_settings.py
+++ b/openstates/test_settings.py
@@ -13,7 +13,7 @@ DATABASES = {
         "NAME": "test",
         "USER": "test",
         "PASSWORD": "test",
-        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
     }
 }
 MIDDLEWARE_CLASSES = ()


### PR DESCRIPTION
Hello,

This PR accommodates my Docker setup to run tests (i.e., `./run-tests.sh`) locally. I have PostgreSQL/PostGIS installed in a separate image, so this allows me to specify that container via the `POSTGRES_HOST` environment variable. The `.gitignore` change allows me to place the virtualenv within the project root so I do not have to reinstall all Python dependencies on each run.

Let me know if you have any questions or if this conflicts with your existing setup. Thanks!