### PR TITLE
Add veto and veto-override vote classifications

### DIFF
--- a/openstates/data/common.py
+++ b/openstates/data/common.py
@@ -142,6 +142,8 @@ VOTE_CLASSIFICATION_CHOICES = (
     ("amendment", "Amendment"),
     ("reading-1", "First Reading"),
     ("reading-3", "Third Reading"),
+    ("veto", "Veto"),
+    ("veto-override", "Veto Override"),
 )
 VOTE_CLASSIFICATIONS = _keys(VOTE_CLASSIFICATION_CHOICES)
 


### PR DESCRIPTION
Allow vote events to be classified as "veto" or "veto-override" 

More info -- https://github.com/openstates/issues/issues/382

