### PR TITLE
no objects

### DIFF
--- a/openstates/exceptions.py
+++ b/openstates/exceptions.py
@@ -58,3 +58,7 @@ class ScrapeError(OpenStatesError):
 
 class ScrapeValueError(OpenStatesError, ValueError):
     """ An invalid value was passed to a scrape object. """
+
+
+class EmptyScrape(OpenStatesError):
+    """ Indicate an intentionally empty scrape. """

--- a/openstates/scrape/__init__.py
+++ b/openstates/scrape/__init__.py
@@ -5,3 +5,4 @@ from .vote_event import VoteEvent
 from .bill import Bill
 from .event import Event
 from .base import Scraper, BaseBillScraper
+from ..exceptions import EmptyScrape


### PR DESCRIPTION
- change validation to include validating parent on final Committee class
- convert_us parent_id fix
- committee merge with parent conversion
- fix merging
- fix mypy linting issue
- fix committee parent lookup for db
- 6.3.1
- stop removing committees on import
- 6.3.2
- add check for missing directory
- fix OS_PEOPLE_DIRECTORY setting
- add/update commitee extras on to-database
- 6.3.3
- don't add contact detail without phone or voice
- 6.3.4
- fix for phone/voice mixup
- latest_bill_update and latest_people_update added to Jurisdiction model
- move reports app into data
- remove reports app exceptions
- add migration 37, moving reports over, should be faked in prod
- add latest_bill_update bump to os-update
- people latest_people_update
- 6.4.0
- ensure parent committees are dealt with before subcommittees
- add --fix to committee lint
- normalize whitespace in strings
- 6.4.1
- add EmptyScrape logic
- add test for EmptyScrape
