### PR TITLE
events redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.5.0
+
+* allow raising `EmptyScrape` to end a scrape without 'no objects returned' error
+* added `upstream_id` to Event model
+* add classification parameter to `Event.add_document`
+* fix up `Event.add_media_link` parameters to be uniform (including classification)
+* added `Event.add_bill` helper method
+
 ## 6.4.1 - August 19 2021
 
 * committee merge bugfix for parent committees

--- a/openstates/data/models/event.py
+++ b/openstates/data/models/event.py
@@ -63,7 +63,9 @@ class Event(OCDBase):
     all_day = models.BooleanField(default=False)
     status = models.CharField(max_length=20, choices=EVENT_STATUS_CHOICES)
     location = models.ForeignKey(EventLocation, null=True, on_delete=models.SET_NULL)
+    upstream_id = models.CharField(max_length=300, blank=True)
     dedupe_key = models.CharField(max_length=500, null=True)
+    deleted = models.BooleanField(default=False)
 
     def __str__(self):
         return "{0} ({1})".format(self.name, self.start_date)

--- a/openstates/scrape/__init__.py
+++ b/openstates/scrape/__init__.py
@@ -3,6 +3,6 @@ from .jurisdiction import Jurisdiction, JurisdictionScraper
 from .popolo import Membership, Organization, Person, Post
 from .vote_event import VoteEvent
 from .bill import Bill
-from .event import Event
+from .event import Event, calculate_window
 from .base import Scraper, BaseBillScraper
 from ..exceptions import EmptyScrape

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -147,6 +147,21 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         self.agenda.append(obj)
         return obj
 
+    def add_bill(self, bill, *, note="consideration", agenda_item="Associated Bills"):
+        """
+        adds a dummy agenda item for associating bills for cases where we want bills
+        but don't have appropriate agenda items
+
+        context: https://github.com/openstates/enhancement-proposals/pull/28#issuecomment-898720989
+        """
+        for item in self.agenda:
+            if item["description"] == agenda_item:
+                break
+        else:
+            item = EventAgendaItem(agenda_item, self)
+            self.agenda.append(item)
+        item.add_bill(bill, note=note)
+
     def add_media_link(
         self,
         note,

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -88,7 +88,8 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         description="",
         end_date="",
         status="confirmed",
-        classification="event"
+        classification="event",
+        upstream_id="",
     ):
         super(Event, self).__init__()
         self.start_date = start_date
@@ -98,6 +99,7 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         self.description = description
         self.status = status
         self.classification = classification
+        self.upstream_id = upstream_id
         self.location = {"name": location_name, "note": "", "coordinates": None}
         self.documents = []
         self.participants = []
@@ -145,7 +147,7 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         text="",
         type="media",
         on_duplicate="error",
-        date=""
+        date="",
     ):
         return self._add_associated_link(
             collection="media",

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -41,7 +41,14 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
         self.add_entity(name=person, entity_type="person", id=id, note=note)
 
     def add_media_link(
-        self, note, url, media_type, *, text="", type="media", on_duplicate="warn"
+        self,
+        note,
+        url,
+        media_type,
+        *,
+        on_duplicate="warn",
+        date="",
+        classification="",
     ):
         return self._add_associated_link(
             collection="media",
@@ -49,6 +56,8 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
             url=url,
             media_type=media_type,
             on_duplicate=on_duplicate,
+            date=date,
+            classification=classification,
         )
 
     def add_entity(self, name, entity_type, *, id, note):
@@ -144,10 +153,9 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
         url,
         media_type,
         *,
-        text="",
-        type="media",
         on_duplicate="error",
         date="",
+        classification="",
     ):
         return self._add_associated_link(
             collection="media",
@@ -156,11 +164,10 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
             media_type=media_type,
             on_duplicate=on_duplicate,
             date=date,
+            classification=classification,
         )
 
-    def add_document(
-        self, note, url, *, text="", media_type="", on_duplicate="error", date=""
-    ):
+    def add_document(self, note, url, *, media_type="", on_duplicate="error", date=""):
         return self._add_associated_link(
             collection="documents",
             note=note,

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -1,7 +1,17 @@
+from datetime import date, timedelta
 from ..exceptions import ScrapeValueError
 from ..utils import _make_pseudo_id
 from .base import BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin
 from .schemas.event import schema
+
+
+def calculate_window(*, base_day=None, days_before=30, days_after=90):
+    """ given details on a window, returns start & end dates for windowing purposes """
+    if not base_day:
+        base_day = date.today()
+    start = base_day - timedelta(days=days_before)
+    end = base_day + timedelta(days=days_after)
+    return start, end
 
 
 class EventAgendaItem(dict, AssociatedLinkMixin):

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -182,7 +182,16 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
             classification=classification,
         )
 
-    def add_document(self, note, url, *, media_type="", on_duplicate="error", date=""):
+    def add_document(
+        self,
+        note,
+        url,
+        *,
+        media_type="",
+        on_duplicate="error",
+        date="",
+        classification="",
+    ):
         return self._add_associated_link(
             collection="documents",
             note=note,
@@ -190,4 +199,5 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
             media_type=media_type,
             on_duplicate=on_duplicate,
             date=date,
+            classification=classification,
         )

--- a/openstates/scrape/schemas/event.py
+++ b/openstates/scrape/schemas/event.py
@@ -45,6 +45,7 @@ schema = {
         },
         "classification": {"type": "string", "minLength": 1},  # TODO: enum
         "description": {"type": "string"},
+        "upstream_id": {"type": "string"},
         "location": {
             "type": "object",
             "properties": {

--- a/openstates/scrape/tests/test_event_scrape.py
+++ b/openstates/scrape/tests/test_event_scrape.py
@@ -111,10 +111,16 @@ def test_add_bill():
 def test_add_document():
     e = event_obj()
     assert e.documents == []
-    e.add_document(note="hello", url="http://example.com", media_type="text/html")
+    e.add_document(
+        note="hello",
+        url="http://example.com",
+        media_type="text/html",
+        classification="testimony",
+    )
     assert len(e.documents) == 1
     o = e.documents[0]
     assert o["note"] == "hello"
+    assert o["classification"] == "testimony"
     assert o["links"] == [{"url": "http://example.com", "media_type": "text/html"}]
     e.validate()
 

--- a/openstates/scrape/tests/test_event_scrape.py
+++ b/openstates/scrape/tests/test_event_scrape.py
@@ -1,6 +1,6 @@
 import pytest
 import datetime
-from openstates.scrape import Event
+from openstates.scrape import Event, calculate_window
 
 
 def event_obj():
@@ -194,3 +194,14 @@ def test_add_bill_on_event():
         "name": "HB 7",
         "note": "passed",
     }
+
+
+def test_calculate_window():
+    base_day = datetime.date(2021, 9, 14)
+    start, end = calculate_window(base_day=base_day)
+    assert start == datetime.date(2021, 8, 15)
+    assert end == datetime.date(2021, 12, 13)
+
+    start, end = calculate_window(base_day=base_day, days_before=1, days_after=1)
+    assert start == datetime.date(2021, 9, 13)
+    assert end == datetime.date(2021, 9, 15)

--- a/openstates/scrape/tests/test_event_scrape.py
+++ b/openstates/scrape/tests/test_event_scrape.py
@@ -168,3 +168,23 @@ def test_add_media():
     e.validate()
     assert len(e.media) == 1
     assert len(e.media[0]["links"]) == 2
+
+
+def test_add_bill_on_event():
+    e = event_obj()
+    e.add_bill("HB 6")
+    e.validate()
+    assert e.agenda[0]["description"] == "Associated Bills"
+    assert e.agenda[0]["related_entities"][0] == {
+        "bill_id": '~{"identifier": "HB 6"}',
+        "entity_type": "bill",
+        "name": "HB 6",
+        "note": "consideration",
+    }
+    e.add_bill("HB 7", note="passed")
+    assert e.agenda[0]["related_entities"][1] == {
+        "bill_id": '~{"identifier": "HB 7"}',
+        "entity_type": "bill",
+        "name": "HB 7",
+        "note": "passed",
+    }


### PR DESCRIPTION
- change validation to include validating parent on final Committee class
- convert_us parent_id fix
- committee merge with parent conversion
- fix merging
- fix mypy linting issue
- fix committee parent lookup for db
- 6.3.1
- stop removing committees on import
- 6.3.2
- add check for missing directory
- fix OS_PEOPLE_DIRECTORY setting
- add/update commitee extras on to-database
- 6.3.3
- don't add contact detail without phone or voice
- 6.3.4
- fix for phone/voice mixup
- latest_bill_update and latest_people_update added to Jurisdiction model
- move reports app into data
- remove reports app exceptions
- add migration 37, moving reports over, should be faked in prod
- add latest_bill_update bump to os-update
- people latest_people_update
- 6.4.0
- ensure parent committees are dealt with before subcommittees
- add --fix to committee lint
- normalize whitespace in strings
- 6.4.1
- add EmptyScrape logic
- add test for EmptyScrape
- warn on EmptyScrape
- add upstream_id to openstates.scrape.event
- add upstream_id and deleted fields to Event model
- add classification parameter to add_media_link on Event
- add Event.add_bill helper
- add classification parameter to add_document on Event
- add openstates.scrape.calculate_window functionality
- WIP changelog
