### PR TITLE
Fixes for the admin UI. Improve support for legislation and org membership.

### DIFF
--- a/openstates/data/admin/base.py
+++ b/openstates/data/admin/base.py
@@ -12,7 +12,7 @@ class ModelAdmin(admin.ModelAdmin):
         return False
 
     # we probably don't want to add anything through the interface
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
     # To ignore `DisallowedModelAdminLookup` error because of non
@@ -22,7 +22,7 @@ class ModelAdmin(admin.ModelAdmin):
 
 
 class ReadOnlyTabularInline(admin.TabularInline):
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
     can_delete = False
@@ -35,7 +35,7 @@ class IdentifierInline(admin.TabularInline):
     verbose_name = "ID from another system"
     verbose_name_plural = "IDs from other systems"
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 

--- a/openstates/data/admin/bill.py
+++ b/openstates/data/admin/bill.py
@@ -72,6 +72,7 @@ class BillVersionInline(DocVersionInline):
     model = models.BillVersion
     readonly_fields = fields = ("date", "note", "classification")
 
+
 class BillDocumentInline(DocVersionInline):
     model = models.BillDocument
 

--- a/openstates/data/admin/organization.py
+++ b/openstates/data/admin/organization.py
@@ -1,5 +1,9 @@
 from django.urls import reverse
 from django.contrib import admin
+from django.utils.html import format_html
+
+from openstates.data.admin.person import MembershipInline
+
 from .. import models
 from .base import ModelAdmin, ReadOnlyTabularInline
 
@@ -9,13 +13,40 @@ class PostInline(admin.TabularInline):
 
     model = models.Post
     extra = 0
-    fields = readonly_fields = ("label", "role")
+    fields = readonly_fields = ("get_label", "role")
     ordering = ("label",)
     can_delete = False
-    show_change_link = True
-
-    def has_add_permission(self, request):
+    
+    def get_label(self, post):
+        admin_url = reverse(
+            "admin:data_post_change", args=(post.pk,)
+        )
+        tmpl = u'<a href="%s">%s</a>'
+        return format_html(tmpl % (admin_url, post.label))
+    
+    get_label.short_description = "Label"
+    
+    def has_add_permission(self, request, obj=None):
         return False
+
+
+class OrganizationInline(ReadOnlyTabularInline):
+    """a read-only inline for posts here, with links to the real thing"""
+
+    model = models.Organization
+    fields = readonly_fields = ("get_name", "jurisdiction", "classification")
+    ordering = ("-classification", "name")
+    
+    def get_name(self, organization):
+        admin_url = reverse(
+            "admin:data_organization_change", args=(organization.pk,)
+        )
+        tmpl = u'<a href="%s">%s</a>'
+        return format_html(tmpl % (admin_url, organization.name))
+
+    get_name.short_description = "ID"
+    get_name.allow_tags = True
+    get_name.admin_order_field = "organization__name"
 
 
 class OrgMembershipInline(ReadOnlyTabularInline):
@@ -25,6 +56,15 @@ class OrgMembershipInline(ReadOnlyTabularInline):
     fields = readonly_fields + ("end_date",)
     extra = 0
     can_delete = False
+    ordering = ("person__name", "start_date")
+
+
+@admin.register(models.Post)
+class PostAdmin(ModelAdmin):
+    readonly_fields = fields = ("id", "division", "organization", "label", "role", "maximum_memberships", "extras")
+    ordering = ("division__id", "organization", "role", "label")
+    inlines = (MembershipInline,)
+    list_display = ("division", "organization", "role", "label")
 
 
 @admin.register(models.Organization)
@@ -44,6 +84,7 @@ class OrganizationAdmin(ModelAdmin):
     inlines = [
         PostInline,
         OrgMembershipInline,
+        OrganizationInline,
     ]
 
     def get_org_name(self, obj):
@@ -63,7 +104,7 @@ class OrganizationAdmin(ModelAdmin):
                 "admin:data_jurisdiction_change", args=(jurisdiction.pk,)
             )
             tmpl = '<a href="%s">%s</a>'
-            return tmpl % (admin_url, jurisdiction.name)
+            return format_html(tmpl % (admin_url, jurisdiction.name))
 
         return "(none)"
 
@@ -73,4 +114,4 @@ class OrganizationAdmin(ModelAdmin):
 
     list_select_related = ("jurisdiction",)
     list_display = ("get_org_name", "get_jurisdiction", "classification")
-    ordering = ("name",)
+    ordering = ("jurisdiction__name", "-classification", "name")

--- a/openstates/data/admin/organization.py
+++ b/openstates/data/admin/organization.py
@@ -16,16 +16,16 @@ class PostInline(admin.TabularInline):
     fields = readonly_fields = ("get_label", "role")
     ordering = ("label",)
     can_delete = False
-    
+
     def get_label(self, post):
         admin_url = reverse(
             "admin:data_post_change", args=(post.pk,)
         )
         tmpl = u'<a href="%s">%s</a>'
         return format_html(tmpl % (admin_url, post.label))
-    
+
     get_label.short_description = "Label"
-    
+
     def has_add_permission(self, request, obj=None):
         return False
 
@@ -36,7 +36,7 @@ class OrganizationInline(ReadOnlyTabularInline):
     model = models.Organization
     fields = readonly_fields = ("get_name", "jurisdiction", "classification")
     ordering = ("-classification", "name")
-    
+
     def get_name(self, organization):
         admin_url = reverse(
             "admin:data_organization_change", args=(organization.pk,)

--- a/openstates/data/admin/other.py
+++ b/openstates/data/admin/other.py
@@ -1,6 +1,34 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
+from openstates.data.admin.organization import OrganizationInline
+
 from .. import models
 from .base import ModelAdmin, ReadOnlyTabularInline
+
+
+class JurisdictionInline(ReadOnlyTabularInline):
+    model = models.Jurisdiction
+    list_display = ("name", "id")
+    readonly_fields = fields = (
+        "get_id",
+        "name",
+        "classification",
+        "extras",
+        "url",
+    )
+    ordering = ("id",)
+
+    def get_id(self, jurisdiction):
+        admin_url = reverse(
+            "admin:data_jurisdiction_change", args=(jurisdiction.pk,)
+        )
+        tmpl = u'<a href="%s">%s</a>'
+        return format_html(tmpl % (admin_url, jurisdiction.name))
+
+    get_id.short_description = "ID"
+    get_id.allow_tags = True
+    get_id.admin_order_field = "jurisdiction__name"
 
 
 @admin.register(models.Division)
@@ -9,17 +37,55 @@ class DivisionAdmin(ModelAdmin):
     search_fields = list_display
     fields = readonly_fields = ("id", "name", "redirect", "country")
     ordering = ("id",)
+    inlines = [JurisdictionInline]
 
 
 class LegislativeSessionInline(ReadOnlyTabularInline):
     model = models.LegislativeSession
-    readonly_fields = ("identifier", "name", "classification", "start_date", "end_date")
+    readonly_fields = ("identifier", "get_name", "classification", "start_date", "end_date")
+    fields = readonly_fields
     ordering = ("-identifier",)
+    
+    def get_name(self, legislative_session):
+        admin_url = reverse(
+            "admin:data_legislativesession_change", args=(legislative_session.pk,)
+        )
+        tmpl = u'<a href="%s">%s</a>'
+        return format_html(tmpl % (admin_url, legislative_session.name))
+    
+    get_name.short_description = "NAME"
+    get_name.allow_tags = True
+
+
+class BillInline(ReadOnlyTabularInline):
+    model = models.Bill
+    readonly_fields = fields = (
+        "get_identifier",
+        "classification",
+        "from_organization",
+        "title",
+        "latest_action_date",
+        "subject",
+    )
+    ordering = ("identifier",)
+
+    def get_identifier(self, bill):
+        admin_url = reverse(
+            "admin:data_bill_change", args=(bill.id,)
+        )
+        tmpl = u'<a href="%s">%s</a>'
+        return format_html(tmpl % (admin_url, bill.identifier))
+
+
+@admin.register(models.LegislativeSession)
+class LegislativeSessionAdmin(ModelAdmin):
+    readonly_fields = ("jurisdiction", "identifier", "name", "active", "classification", "start_date", "end_date")
+    inlines = [BillInline]
 
 
 @admin.register(models.Jurisdiction)
 class JurisdictionAdmin(ModelAdmin):
-    list_display = ("name", "id")
+    list_display = ("name", "id", "classification")
     readonly_fields = fields = (
         "id",
         "name",
@@ -29,4 +95,5 @@ class JurisdictionAdmin(ModelAdmin):
         "url",
     )
     ordering = ("id",)
-    inlines = [LegislativeSessionInline]
+    search_fields = ("id", "name")
+    inlines = [LegislativeSessionInline, OrganizationInline]

--- a/openstates/data/admin/other.py
+++ b/openstates/data/admin/other.py
@@ -45,14 +45,14 @@ class LegislativeSessionInline(ReadOnlyTabularInline):
     readonly_fields = ("identifier", "get_name", "classification", "start_date", "end_date")
     fields = readonly_fields
     ordering = ("-identifier",)
-    
+
     def get_name(self, legislative_session):
         admin_url = reverse(
             "admin:data_legislativesession_change", args=(legislative_session.pk,)
         )
         tmpl = u'<a href="%s">%s</a>'
         return format_html(tmpl % (admin_url, legislative_session.name))
-    
+
     get_name.short_description = "NAME"
     get_name.allow_tags = True
 
@@ -94,6 +94,6 @@ class JurisdictionAdmin(ModelAdmin):
         "extras",
         "url",
     )
-    ordering = ("id",)
+    ordering = ("-classification", "id",)
     search_fields = ("id", "name")
     inlines = [LegislativeSessionInline, OrganizationInline]

--- a/openstates/data/admin/person.py
+++ b/openstates/data/admin/person.py
@@ -35,11 +35,12 @@ class PersonSourceInline(ReadOnlyTabularInline):
 
 class MembershipInline(ReadOnlyTabularInline):
     model = models.Membership
-    readonly_fields = ("organization", "post", "role", "start_date")
+    readonly_fields = ("organization", "person", "post", "role", "start_date")
     fields = ("id",) + readonly_fields + ("end_date",)
     exclude = ("id",)
     extra = 0
     can_delete = False
+    ordering = ("end_date",)
 
 
 # TODO field locking

--- a/openstates/data/admin/reports.py
+++ b/openstates/data/admin/reports.py
@@ -7,7 +7,7 @@ class ScrapeReportInline(admin.TabularInline):
     model = models.ScrapeReport
     readonly_fields = ("scraper", "args", "start_time", "end_time", "get_object_list")
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
     can_delete = False
@@ -29,7 +29,7 @@ class ImportObjectsInline(admin.TabularInline):
         "end_time",
     )
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
     can_delete = False
@@ -54,7 +54,7 @@ class RunPlanAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 

--- a/openstates/data/admin/vote.py
+++ b/openstates/data/admin/vote.py
@@ -33,7 +33,6 @@ class VoteEventAdmin(ModelAdmin):
         "result",
         "motion_classification",
         "start_date",
-        "end_date",
     )
 
     list_selected_related = (


### PR DESCRIPTION
Remove end_date VoteEventAdmin.
Fix the has_add_permission overrides. Admin works now.
Add some additional Inlines to extend support for Legislation.
Extend support for Organization membership and Posts.
Make readonly some fields that should be.
Improve ordering and search for several models.
Fix HTML rendering for certain fields by using format_html.