### PR TITLE
validate person name on role

### DIFF
--- a/openstates/models/committees.py
+++ b/openstates/models/committees.py
@@ -32,6 +32,13 @@ class Membership(BaseModel):
     _validate_name = validator("name", allow_reuse=True)(validate_str_no_newline)
     _validate_role = validator("role", allow_reuse=True)(validate_str_no_newline)
 
+    @validator("name")
+    def not_blank(cls, val: str) -> str:
+        val = val.strip()
+        if not val:
+            raise ValueError("empty name")
+        return val
+
 
 class ScrapeCommittee(BaseModel):
     name: str


### PR DESCRIPTION
- First pass at legal citations
- Citation changes to pass tests
- Fix citation tests
- Flake8 fixes
- new people merge WIP
- fix stray Replaces and contact details checking
- move merge code into os-people merge
- rename test
- remove stray script
- fix mypy issue
- 6.5.0 bump, changelog updated
- EventLink/Source to new JSON style
- add migration for last commit
- remove eventLink & EventSource references
- more links removed on events
- remove more event links from admin/importer
- fix failing tests
- event soft deletion [squashed]
- update changelog for release
- enable vote importing by default
- fix for committee_id being set instead of organization_id
- 6.5.1 bump
- fix test
- fix legislator_id on event import too
- more flexible DuplicateItemError logic & stray black update
- add resolve_bill method
- apply bill transformer to bill_id
- remove BillImporter req on EventImporter, allows matching correctly
- oops, this is important: fix identifier lookup on match_bill
- add shortcut to skip BillImporter.postimport if no bills are imported
- 6.5.2
- fix situation where postimport wipes out events
- 6.5.3
- fix merge committees to handle parents correctly
- case insensitive matching on committees
- update changelog w/ latest
- switch Contact -> Office, and fix linting
- fix for ContactDetails -> Offices
- add PersonOffice
- fix committee tests that were already failing
- lots of contact_details->offices fixes
- fix counting of capitol offices
- offices for US
- Offices: use display_name as merge key
- offices: to_database tweaks
- removal of old openstates.scrape.Person
- remove old scrape pieces
- fix mypy stuff
- change django admin for offices
- update changelog
- 6.6.0
- fix missing exported models
- bugfix for convert_us
- 6.6.1
- remove to-database contact_details shim
- fix test for contact_details
- remove contact_details
- remove PersonContactDetail
- remove PersonContactDetail table
- 6.7.0
- add LegislativeSession.active
- scrape.Jurisdiction is now scrape.State
- use State objects for scraping
- check for active sessions
- add type checking to update
- inject sessions if required
- remove reference to scrape.Jurisdiction
- fix for tests without Jurisdiction mutability
- remove latest_session, which is an antipattern
- update changelog
- 6.8.0
- Solve circular dependency issue in the metadata package.
- fix tests
- fix tests
- fix lint
- 6.8.1
- fix for duplicate items in lists
- lint that committees have members
- 6.8.2
- type ignore
- add citations field
- 0044
- fix validation
- fix some of the committee tests
- fix other committee tests
- fix test data
- Fix the Admin UI.  Remove end_date VoteEventAdmin. Fix the has_add_permission overrides. Add some additional Inlines to extend support for Legislation. Extend support for Organization membership and Posts.
- update changelog
- deal with placeholder member in convert_us
- 6.9.0
- flakes
- update process_office to not need an office type
- fix bad dashes in US data
- 6.9.1
- mypy missed func
- validate person name on role
