### PR TITLE
People merge updates

### DIFF
--- a/openstates/utils/people/merge.py
+++ b/openstates/utils/people/merge.py
@@ -356,6 +356,7 @@ def incoming_merge(
         else:
             # not matched
             unmatched.append((new, role_matches))
+            write_new_file(abbr, new, "legislature")
 
     return unmatched
 

--- a/openstates/utils/people/merge.py
+++ b/openstates/utils/people/merge.py
@@ -261,7 +261,7 @@ def compute_merge(
                 changed_offices = val2
             else:
                 changed_offices = merge_offices(val1, val2)
-            if changed:
+            if changed_offices:
                 changes.append(OfficesReplace("offices", val1 or [], changed_offices))
         elif isinstance(val1, list) or isinstance(val2, list):
             if val1 and not val2:

--- a/openstates/utils/tests/test_merge.py
+++ b/openstates/utils/tests/test_merge.py
@@ -299,6 +299,49 @@ def test_keep_both_ids(old, new, expected):
 
 
 @pytest.mark.parametrize(
+    "old, new, expected",
+    [
+        # no change
+        (
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1111")],
+            },
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1111")],
+            },
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1111")],
+            },
+        ),
+        # change in voice
+        (
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1111")],
+            },
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1112")],
+            },
+            {
+                "id": "ocd-person/1",
+                "offices": [Office(classification="capitol", voice="111-111-1112")],
+            },
+        ),
+    ],
+)
+def test_merge_with_offices(old, new, expected):
+    class Model(BaseModel):
+        id: str
+        offices: list[Office] = []
+
+    assert merge_people(Model(**old), Model(**new)) == Model(**expected)
+
+
+@pytest.mark.parametrize(
     "old, new",
     [
         (


### PR DESCRIPTION
Fix bug in merging offices:
The wrong variable was referenced when determining whether offices changed, meaning that offices were not always merged correctly. This change references the correct variable.

People merge: write unmerged legislators:
This change assumes that all unmerged legislators are new. Open to suggestions here, but it seems that we should do something with those who are unmerged.