### PR TITLE
Ignore subcommittee membership when updating people

### DIFF
--- a/openstates/utils/people/to_database.py
+++ b/openstates/utils/people/to_database.py
@@ -240,7 +240,7 @@ def load_person(data: Person) -> tuple[bool, bool]:
         "memberships",
         memberships,
         read_manager=person.memberships.exclude(
-            organization__classification="committee"
+            organization__classification__in=["committee", "subcommittee"]
         ),
     )
 


### PR DESCRIPTION
Currently, only committee membership is ignored when comparing YAML memberships to the database. Subcommittee membership should be ignored here as well.