### PR TITLE
duplicate com names

### DIFF
--- a/openstates/utils/tests/test_committees.py
+++ b/openstates/utils/tests/test_committees.py
@@ -180,8 +180,8 @@ def test_merge_committees_members():
 def test_load_data():
     comdir = CommitteeDir(abbr="wa", directory=TEST_DATA_PATH / "committees")
 
-    assert len(comdir.coms_by_chamber_and_name["lower"]) == 3
-    assert len(comdir.coms_by_chamber_and_name["upper"]) == 1
+    assert len(comdir.coms_by_parent_and_name["lower"]) == 3
+    assert len(comdir.coms_by_parent_and_name["upper"]) == 1
     assert comdir.errors == []
 
 
@@ -192,8 +192,8 @@ def test_load_data_with_errors():
         raise_errors=False,
     )
 
-    assert len(comdir.coms_by_chamber_and_name["lower"]) == 0
-    assert len(comdir.coms_by_chamber_and_name["upper"]) == 0
+    assert len(comdir.coms_by_parent_and_name["lower"]) == 0
+    assert len(comdir.coms_by_parent_and_name["upper"]) == 0
     assert len(comdir.errors) == 2
     # error order isn't deterministic
     path0, msg0 = comdir.errors[0]
@@ -293,7 +293,7 @@ def test_add_committee():
             members=[Membership(name="Someone", role="member")],
         )
         comdir.add_committee(sc)
-        full_com = comdir.coms_by_chamber_and_name[sc.chamber][sc.name]
+        full_com = comdir.coms_by_parent_and_name[sc.chamber][sc.name]
         assert full_com.name == sc.name
         assert full_com.id.startswith("ocd-organization")
         assert full_com.jurisdiction == JURISDICTION_ID
@@ -330,7 +330,7 @@ def test_ingest_scraped_json_names_resolved():
     assert committees[1].name == "Judiciary 4"
 
 
-def test_get_merge_plan_by_chamber(person_matcher):
+def test_get_merge_plan_by_parent(person_matcher):
     comdir = CommitteeDir(
         abbr="wa",
         directory=TEST_DATA_PATH / "committees",
@@ -373,7 +373,7 @@ def test_get_merge_plan_by_chamber(person_matcher):
         ),
     ]
 
-    plan = comdir.get_merge_plan_by_chamber("lower", newdata)
+    plan = comdir.get_merge_plan_by_parent("lower", newdata)
     assert plan.names_to_add == {"Science"}
     assert plan.names_to_remove == {"Agriculture"}
     assert plan.same == 1  # Edcuation


### PR DESCRIPTION
- First pass at legal citations
- Citation changes to pass tests
- Fix citation tests
- Flake8 fixes
- new people merge WIP
- fix stray Replaces and contact details checking
- move merge code into os-people merge
- rename test
- remove stray script
- fix mypy issue
- 6.5.0 bump, changelog updated
- EventLink/Source to new JSON style
- add migration for last commit
- remove eventLink & EventSource references
- more links removed on events
- remove more event links from admin/importer
- fix failing tests
- event soft deletion [squashed]
- update changelog for release
- enable vote importing by default
- fix for committee_id being set instead of organization_id
- 6.5.1 bump
- fix test
- fix legislator_id on event import too
- more flexible DuplicateItemError logic & stray black update
- add resolve_bill method
- apply bill transformer to bill_id
- remove BillImporter req on EventImporter, allows matching correctly
- oops, this is important: fix identifier lookup on match_bill
- add shortcut to skip BillImporter.postimport if no bills are imported
- 6.5.2
- fix situation where postimport wipes out events
- 6.5.3
- fix merge committees to handle parents correctly
- case insensitive matching on committees
- update changelog w/ latest
- switch Contact -> Office, and fix linting
- fix for ContactDetails -> Offices
- add PersonOffice
- fix committee tests that were already failing
- lots of contact_details->offices fixes
- fix counting of capitol offices
- offices for US
- Offices: use display_name as merge key
- offices: to_database tweaks
- removal of old openstates.scrape.Person
- remove old scrape pieces
- fix mypy stuff
- change django admin for offices
- update changelog
- 6.6.0
- fix missing exported models
- bugfix for convert_us
- 6.6.1
- remove to-database contact_details shim
- fix test for contact_details
- remove contact_details
- remove PersonContactDetail
- remove PersonContactDetail table
- 6.7.0
- add LegislativeSession.active
- scrape.Jurisdiction is now scrape.State
- use State objects for scraping
- check for active sessions
- add type checking to update
- inject sessions if required
- remove reference to scrape.Jurisdiction
- fix for tests without Jurisdiction mutability
- remove latest_session, which is an antipattern
- update changelog
- 6.8.0
- Solve circular dependency issue in the metadata package.
- fix tests
- fix tests
- fix lint
- 6.8.1
- fix for duplicate items in lists
- lint that committees have members
- 6.8.2
- type ignore
- add citations field
- 0044
- fix validation
- fix some of the committee tests
- fix other committee tests
- fix test data
- Fix the Admin UI.  Remove end_date VoteEventAdmin. Fix the has_add_permission overrides. Add some additional Inlines to extend support for Legislation. Extend support for Organization membership and Posts.
- update changelog
- deal with placeholder member in convert_us
- 6.9.0
- flakes
- update process_office to not need an office type
- fix bad dashes in US data
- 6.9.1
- mypy missed func
- validate person name on role
- update committee validation
- add migration to initdb
- 6.9.2
- URL validation of empty urls
- add os-scrape command for people
- update changelog for os-scrape
- improve office merging to avoid duplicates
- scrape command uses --rmdir from poetry 0.8.8
- party merge
- update changelog
- fix for party merge
- add FNP to suffixes list
- --*only flags to os-scrape
- more automated merging in multi-member states
- add --fastmode to os-scrape
- spatula 0.8.9
- ignore spatula artifacts
- cleanup people merge
- --reset-offices flag for heavy merges
- update changelog
- mypy
- 6.10.0
- os-scrape committees
- merge extras
- add --interactive flag to slow down & prompt for changes
- 6.10.1
- Coms import: fix for null com
- Fix bug in merging offices
- People merge: write unmerged legislators
- active roles rules ignored for executive too for now
- 6.10.2
- Ignore subcommittee membership when updating people
- update changelog
- add --session options for os-text-extract
- CA text extraction, #147
- CA text extraction, openstates/issues#147
- 6.10.3
- 6.10.4
- US: text extraction
- fix for openstates/issues#608
- 6.10.5
- 6.10.6
- handle duplicate committee names with different parents
