### PR TITLE
allow for returning None objects from scrapes

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -162,6 +162,9 @@ class Scraper(scrapelib.Scraper):
         record["start"] = utils.utcnow()
         try:
             for obj in self.scrape(**kwargs) or []:
+                # allow for returning empty objects in a list
+                if not obj:
+                    continue
                 if hasattr(obj, "__iter__"):
                     for iterobj in obj:
                         self.save_object(iterobj)


### PR DESCRIPTION
There may be cases where, in a particular scraper, we need to return a `None` because we _know_ that a page/vote/etc. is bad, but all the pages _around_ that page are okay. Adding this simple step lets us do that safely within `scrape()`.

Signed-off-by: John Seekins <john@civiceagle.com>