### PR TITLE
default to ignoring certificate errors

### DIFF
--- a/openstates/settings.py
+++ b/openstates/settings.py
@@ -8,7 +8,9 @@ SCRAPELIB_TIMEOUT = 60
 SCRAPELIB_RETRY_ATTEMPTS = 3
 SCRAPELIB_RETRY_WAIT_SECONDS = 10
 try:
-    verify = bool(os.environ.get("VERIFY_CERTS", False))
+    verify = os.environ.get("VERIFY_CERTS", False)
+    if verify == "False":
+        verify = False
 except Exception:
     verify = False
 SCRAPELIB_VERIFY = verify

--- a/openstates/settings.py
+++ b/openstates/settings.py
@@ -7,7 +7,11 @@ SCRAPELIB_RPM = 60
 SCRAPELIB_TIMEOUT = 60
 SCRAPELIB_RETRY_ATTEMPTS = 3
 SCRAPELIB_RETRY_WAIT_SECONDS = 10
-SCRAPELIB_VERIFY = True
+try:
+    verify = bool(os.environ.get("VERIFY_CERTS", False))
+except Exception:
+    verify = False
+SCRAPELIB_VERIFY = verify
 
 CACHE_DIR = os.path.join(os.getcwd(), "_cache")
 SCRAPED_DATA_DIR = os.path.join(os.getcwd(), "_data")


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

https://github.com/openstates/openstates-core/blob/main/openstates/scrape/base.py#L86 <- because we use this setting to define whether we want to verify certs or not, this change should cover _all_ configs.

Briefly mentioned in slack here: https://open-states.slack.com/archives/CQ1CUSRFG/p1660076901466619