### PR TITLE
don't try to send a session when one doesn't exist

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -137,16 +137,17 @@ def do_scrape(
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
             stats.send_counter(
-                "session_scrapes_total",
+                "non_session_scrapes_total",
                 1,
                 {
                     "jurisdiction": juris.name,
-                    "session": scrape_args["session"],
                 },
             )
             stats.send_last_run(
-                "last_session_scrape_time",
-                {"jurisdiction": juris.name, "session": session},
+                "last_non_session_scrape_time",
+                {
+                    "jurisdiction": juris.name,
+                },
             )
 
     return report
@@ -187,6 +188,7 @@ def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
     seen_sessions = set()
     seen_sessions.update(bill_importer.get_seen_sessions())
     seen_sessions.update(vote_event_importer.get_seen_sessions())
+    # seen_sessions.update(event_importer.get_seen_sessions())
     for session in seen_sessions:
         generate_session_report(session)
 

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -136,19 +136,31 @@ def do_scrape(
                 realtime=args.realtime,
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
-            stats.send_counter(
-                "non_session_scrapes_total",
-                1,
-                {
-                    "jurisdiction": juris.name,
-                },
-            )
-            stats.send_last_run(
-                "last_non_session_scrape_time",
-                {
-                    "jurisdiction": juris.name,
-                },
-            )
+            session = scrape_args.get("session", None)
+            if session:
+                stats.send_counter(
+                    "session_scrapes_total",
+                    1,
+                    {"jurisdiction": juris.name, "session": session},
+                )
+                stats.send_last_run(
+                    "last_session_scrape_time",
+                    {"jurisdiction": juris.name, "session": session},
+                )
+            else:
+                stats.send_counter(
+                    "non_session_scrapes_total",
+                    1,
+                    {
+                        "jurisdiction": juris.name,
+                    },
+                )
+                stats.send_last_run(
+                    "last_non_session_scrape_time",
+                    {
+                        "jurisdiction": juris.name,
+                    },
+                )
 
     return report
 

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -136,7 +136,7 @@ def do_scrape(
                 realtime=args.realtime,
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
-            session = scrape_args.get("session", None)
+            session = scrape_args.get("session", "")
             if session:
                 stats.send_counter(
                     "session_scrapes_total",

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -188,7 +188,6 @@ def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
     seen_sessions = set()
     seen_sessions.update(bill_importer.get_seen_sessions())
     seen_sessions.update(vote_event_importer.get_seen_sessions())
-    # seen_sessions.update(event_importer.get_seen_sessions())
     for session in seen_sessions:
         generate_session_report(session)
 


### PR DESCRIPTION
A bug in stat emission. We need to actually check for the existence of the `session` key in `scraper_args` before trying to call it.

Signed-off-by: John Seekins <john@civiceagle.com>