### PR TITLE
fix: nj participants id validation

### DIFF
--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -16,6 +16,9 @@ def calculate_window(*, base_day=None, days_before=30, days_after=90):
 
 
 def is_valid_uuid(val):
+    """
+    Check if a string is a valid UUID.
+    """
     try:
         uuid.UUID(str(val))
         return True

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -3,15 +3,24 @@ from ..exceptions import ScrapeValueError
 from ..utils import _make_pseudo_id
 from .base import BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin
 from .schemas.event import schema
+import uuid
 
 
 def calculate_window(*, base_day=None, days_before=30, days_after=90):
-    """ given details on a window, returns start & end dates for windowing purposes """
+    """given details on a window, returns start & end dates for windowing purposes"""
     if not base_day:
         base_day = date.today()
     start = base_day - timedelta(days=days_before)
     end = base_day + timedelta(days=days_after)
     return start, end
+
+
+def is_valid_uuid(val):
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False
 
 
 class EventAgendaItem(dict, AssociatedLinkMixin):
@@ -72,7 +81,7 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
 
     def add_entity(self, name, entity_type, *, id, note):
         ret = {"name": name, "entity_type": entity_type, "note": note}
-        if id:
+        if is_valid_uuid(id):
             ret["id"] = id
         elif entity_type:
             if entity_type in ("organization", "person"):
@@ -138,7 +147,7 @@ class Event(BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin):
 
     def add_participant(self, name, type, *, id=None, note="participant"):
         p = {"name": name, "entity_type": type, "note": note}
-        if id:
+        if is_valid_uuid(id):
             p["id"] = id
         elif type:
             id = _make_pseudo_id(name=name)

--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -1,9 +1,9 @@
 from datetime import date, timedelta
-from ..exceptions import ScrapeValueError
-from ..utils import _make_pseudo_id
+
 from .base import BaseModel, SourceMixin, AssociatedLinkMixin, LinkMixin
 from .schemas.event import schema
-import uuid
+from ..exceptions import ScrapeValueError
+from ..utils import _make_pseudo_id, is_valid_uuid
 
 
 def calculate_window(*, base_day=None, days_before=30, days_after=90):
@@ -13,17 +13,6 @@ def calculate_window(*, base_day=None, days_before=30, days_after=90):
     start = base_day - timedelta(days=days_before)
     end = base_day + timedelta(days=days_after)
     return start, end
-
-
-def is_valid_uuid(val):
-    """
-    Check if a string is a valid UUID.
-    """
-    try:
-        uuid.UUID(str(val))
-        return True
-    except ValueError:
-        return False
 
 
 class EventAgendaItem(dict, AssociatedLinkMixin):

--- a/openstates/utils/__init__.py
+++ b/openstates/utils/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from .generic import (
     _make_pseudo_id,
+    is_valid_uuid,
     get_pseudo_id,
     makedirs,
     JSONEncoderPlus,

--- a/openstates/utils/generic.py
+++ b/openstates/utils/generic.py
@@ -7,9 +7,14 @@ import typing
 import uuid
 
 
-def is_valid_uuid(val):
+def is_valid_uuid(val: str) -> bool:
     """
     Check if a string is a valid UUID.
+
+    Parameters
+    ----------
+    val : str
+        The string to be checked.
     """
     try:
         uuid.UUID(str(val))

--- a/openstates/utils/generic.py
+++ b/openstates/utils/generic.py
@@ -1,9 +1,21 @@
-import typing
-import os
-import json
-import pytz
 import datetime
+import json
+import os
+import pytz
 import subprocess
+import typing
+import uuid
+
+
+def is_valid_uuid(val):
+    """
+    Check if a string is a valid UUID.
+    """
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False
 
 
 def utcnow() -> datetime.datetime:
@@ -11,7 +23,7 @@ def utcnow() -> datetime.datetime:
 
 
 def _make_pseudo_id(**kwargs: str) -> str:
-    """ pseudo ids are just JSON """
+    """pseudo ids are just JSON"""
     # ensure keys are sorted so that these are deterministic
     return "~" + json.dumps(kwargs, sort_keys=True)
 


### PR DESCRIPTION
This fix handles issues from bill imports on NJ event scrapers. The value for participant id is "A" instead of a uuid. This value is currently retrieved from a file during nj event scraping, "AGENDAS.TXT". The code did not validate the uuid, it only check for presence of a uuid - this PR validates the id is a uuid to ensure that a `pseudo id` is created for `participants` when the `id` isn't valid