### PR TITLE
Fix convert_us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.13.5 - January 4, 2023
+
+* check for congress bio info existing before assigning values
+
 ## 6.13.4 - January 3, 2023
 
 * properly handle bad UUIDs in event objects

--- a/openstates/cli/convert_us.py
+++ b/openstates/cli/convert_us.py
@@ -83,14 +83,16 @@ def current_to_person(current: dict[str, typing.Any]) -> tuple[str, Person]:
         "official_full", f"{current['name']['first']} {current['name']['last']}"
     )
     bioguide = current["id"]["bioguide"]
+    gender = current["bio"]["gender"] if current["bio"]["gender"] else ""
+    birthday = current["bio"]["birthday"] if current["bio"]["birthday"] else ""
     p = Person(
         id=make_person_id(bioguide),
         name=full_name,
         given_name=current["name"]["first"],
         family_name=current["name"]["last"],
         middle_name=current["name"].get("middle", ""),
-        gender=current["bio"]["gender"],
-        birth_date=current["bio"]["birthday"],
+        gender=gender,
+        birth_date=birthday,
         roles=[],
     )
     for key, value in current["id"].items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.13.4"
+version = "6.13.5"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Currently the Update US workflow is [failing](https://github.com/openstates/people/actions/runs/3836973726/jobs/6531746882). Not all new Congress folks have bio info in [the file](https://github.com/unitedstates/congress-legislators/blob/fba259fa479c6a4543f5d9c9e72eea9c29e48950/legislators-current.yaml) we're pulling from (they just made birthdays/gender not required [yesterday](https://github.com/unitedstates/congress-legislators/commit/a0638240efdd74d3d384aa42784aa73ad94eb353)), so just adding a check for those values
CC: @jessemortenson @johnseekins @bfossen-ce 