### PR TITLE
USA: Update legacy districts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.13.8 - January 9, 2023
+
+* update us legacy districts
+
 ## 6.13.7 - January 9, 2023
 
 * update us district numbers

--- a/openstates/metadata/data/legacy_districts.py
+++ b/openstates/metadata/data/legacy_districts.py
@@ -80,6 +80,8 @@ legacy_districts = {
         District("Windsor-6-2", "lower", division_id=None),
     ],
     "us": [
+        District("CA-53", "lower", division_id=None),
+        District("IL-18", "lower", division_id=None),
         District("IL-20", "lower", division_id=None),
         District("MA-10", "lower", division_id=None),
         District("MI-14", "lower", division_id=None),
@@ -92,5 +94,6 @@ legacy_districts = {
         District("OH-18", "lower", division_id=None),
         District("OK-6", "lower", division_id=None),
         District("PA-18", "lower", division_id=None),
+        District("WV-3", "lower", division_id=None),
     ],
 }

--- a/openstates/metadata/data/legacy_districts.py
+++ b/openstates/metadata/data/legacy_districts.py
@@ -82,11 +82,15 @@ legacy_districts = {
     "us": [
         District("IL-20", "lower", division_id=None),
         District("MA-10", "lower", division_id=None),
+        District("MI-14", "lower", division_id=None),
         District("MO-9", "lower", division_id=None),
         District("NJ-13", "lower", division_id=None),
         District("NY-29", "lower", division_id=None),
+        District("NY-27", "lower", division_id=None),
+        District("OH-16", "lower", division_id=None),
         District("OH-17", "lower", division_id=None),
         District("OH-18", "lower", division_id=None),
         District("OK-6", "lower", division_id=None),
+        District("PA-18", "lower", division_id=None),
     ],
 }

--- a/openstates/metadata/data/vt.py
+++ b/openstates/metadata/data/vt.py
@@ -283,7 +283,7 @@ VT = State(
                 "Franklin-1",
                 "lower",
                 "ocd-division/country:us/state:vt/sldl:franklin-1",
-                2,
+                1,
             ),
             District(
                 "Franklin-2",

--- a/openstates/metadata/data/vt.py
+++ b/openstates/metadata/data/vt.py
@@ -283,7 +283,7 @@ VT = State(
                 "Franklin-1",
                 "lower",
                 "ocd-division/country:us/state:vt/sldl:franklin-1",
-                1,
+                2,
             ),
             District(
                 "Franklin-2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.13.7"
+version = "6.13.8"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
With the redistricting, have a few seats that disappeared, updating to avoid them. Breaking it up by legislature based off lint fixes.

Don't delete this branch after merging - will have more updates as we get through lint fixes & I want them on the same branch