### PR TITLE
add nomination event agenda type

### DIFF
--- a/openstates/scrape/event.py
+++ b/openstates/scrape/event.py
@@ -78,7 +78,7 @@ class EventAgendaItem(dict, AssociatedLinkMixin):
         elif entity_type:
             if entity_type in ("organization", "person"):
                 id = _make_pseudo_id(name=name)
-            elif entity_type in ("bill", "vote_event"):
+            elif entity_type in ("bill", "vote_event", "nomination"):
                 id = _make_pseudo_id(identifier=name)
             else:
                 raise ScrapeValueError(


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

Associated with this error in USA events:

```
01:52:11 INFO scrapelib: GET - 'https://www.senate.gov/general/committee_schedules/hearings.xml'
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/bin/os-update", line 8, in <module>
    sys.exit(main())
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 478, in main
    report = do_update(args, other, juris)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 303, in do_update
    report["scrape"] = do_scrape(juris, args, scrapers, active_sessions)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 115, in do_scrape
    partial_report = scraper.do_scrape(**scrape_args, session=session)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/scrape/base.py", line 233, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/opt/openstates/openstates/scrapers/usa/events.py", line 63, in scrape
    for event in self.scrape_senate():
  File "/opt/openstates/openstates/scrapers/usa/events.py", line 135, in scrape_senate
    agenda_item.add_entity(
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/scrape/event.py", line 84, in add_entity
    raise ScrapeValueError(
openstates.exceptions.ScrapeValueError: attempt to call add_entity with unsupported entity type: nomination
```

The [associated code](https://github.com/openstates/openstates-scrapers/blob/main/scrapers/usa/events.py#L129) was confident that `nomination` was a valid type...