### PR TITLE
CLI: add os-validate command to validate JSON files against schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
         exclude: openstates/il/tests/
 
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 23.1.0
     hooks:
       - id: black

--- a/openstates/cli/validate.py
+++ b/openstates/cli/validate.py
@@ -34,6 +34,7 @@ def main(
     elif scraper_entity_type == "vote_event":
         schema = vote_event_schema
 
+    # See openstates/scrape/base.py for source of this validation code
     type_checker = Draft3Validator.TYPE_CHECKER.redefine(
         "datetime", lambda c, d: isinstance(d, (datetime.date, datetime.datetime))
     )

--- a/openstates/cli/validate.py
+++ b/openstates/cli/validate.py
@@ -1,0 +1,53 @@
+import click
+import json
+import datetime
+import jsonschema
+from jsonschema import validate, Draft3Validator, FormatChecker
+from ..scrape.schemas.bill import schema as bill_schema
+from ..scrape.schemas.event import schema as event_schema
+from ..scrape.schemas.jurisdiction import schema as jurisdiction_schema
+from ..scrape.schemas.organization import schema as organization_schema
+from ..scrape.schemas.vote_event import schema as vote_event_schema
+
+@click.command()
+@click.argument("scraper_entity_type")
+@click.argument("filepath", type=click.Path(exists=True))
+def main(
+    scraper_entity_type: str,
+    filepath: str,
+) -> None:
+    """Validate a JSON file against scraper data schema. scraper_entity_type may be bill, event, jurisdiction,
+    organization, vote_event. filepath needs to be a json file"""
+    with open(filepath) as json_file:
+        entity_instance = json.load(json_file)
+
+    schema = None
+    if scraper_entity_type == 'bill':
+        schema = bill_schema
+    elif scraper_entity_type == 'event':
+        schema = event_schema
+    elif scraper_entity_type == 'jurisdiction':
+        schema = jurisdiction_schema
+    elif scraper_entity_type == 'organization':
+        schema = organization_schema
+    elif scraper_entity_type == 'vote_event':
+        schema = vote_event_schema
+
+    type_checker = Draft3Validator.TYPE_CHECKER.redefine(
+        "datetime", lambda c, d: isinstance(d, (datetime.date, datetime.datetime))
+    )
+    type_checker = type_checker.redefine(
+        "date",
+        lambda c, d: (
+                isinstance(d, datetime.date) and not isinstance(d, datetime.datetime)
+        ),
+    )
+    ValidatorCls = jsonschema.validators.extend(
+        Draft3Validator, type_checker=type_checker
+    )
+    # validator = ValidatorCls(schema, format_checker=FormatChecker())
+    validate(instance=entity_instance, schema=schema, cls=ValidatorCls)
+
+
+if __name__ == "__main__":
+    main()

--- a/openstates/cli/validate.py
+++ b/openstates/cli/validate.py
@@ -2,12 +2,13 @@ import click
 import json
 import datetime
 import jsonschema
-from jsonschema import validate, Draft3Validator, FormatChecker
+from jsonschema import validate, Draft3Validator
 from ..scrape.schemas.bill import schema as bill_schema
 from ..scrape.schemas.event import schema as event_schema
 from ..scrape.schemas.jurisdiction import schema as jurisdiction_schema
 from ..scrape.schemas.organization import schema as organization_schema
 from ..scrape.schemas.vote_event import schema as vote_event_schema
+
 
 @click.command()
 @click.argument("scraper_entity_type")
@@ -22,15 +23,15 @@ def main(
         entity_instance = json.load(json_file)
 
     schema = None
-    if scraper_entity_type == 'bill':
+    if scraper_entity_type == "bill":
         schema = bill_schema
-    elif scraper_entity_type == 'event':
+    elif scraper_entity_type == "event":
         schema = event_schema
-    elif scraper_entity_type == 'jurisdiction':
+    elif scraper_entity_type == "jurisdiction":
         schema = jurisdiction_schema
-    elif scraper_entity_type == 'organization':
+    elif scraper_entity_type == "organization":
         schema = organization_schema
-    elif scraper_entity_type == 'vote_event':
+    elif scraper_entity_type == "vote_event":
         schema = vote_event_schema
 
     type_checker = Draft3Validator.TYPE_CHECKER.redefine(
@@ -39,13 +40,12 @@ def main(
     type_checker = type_checker.redefine(
         "date",
         lambda c, d: (
-                isinstance(d, datetime.date) and not isinstance(d, datetime.datetime)
+            isinstance(d, datetime.date) and not isinstance(d, datetime.datetime)
         ),
     )
     ValidatorCls = jsonschema.validators.extend(
         Draft3Validator, type_checker=type_checker
     )
-    # validator = ValidatorCls(schema, format_checker=FormatChecker())
     validate(instance=entity_instance, schema=schema, cls=ValidatorCls)
 
 

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -178,7 +178,6 @@ class Scraper(scrapelib.Scraper):
         self.output_names[obj._type].add(filename)
 
         if self.scrape_output_handler is None:
-
             file_path = os.path.join(self.datadir, filename)
 
             # Remove redundant prefix
@@ -190,7 +189,6 @@ class Scraper(scrapelib.Scraper):
                 upload_file_path = file_path
 
             if self.realtime:
-
                 self.output_file_path = str(upload_file_path)
 
                 s3 = boto3.client("s3")
@@ -321,6 +319,7 @@ class BaseModel(object):
         if schema is None:
             schema = self._schema
 
+        # this code copied to openstates/cli/validate - maybe update it if changes here :)
         type_checker = Draft3Validator.TYPE_CHECKER.redefine(
             "datetime", lambda c, d: isinstance(d, (datetime.date, datetime.datetime))
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1709,6 +1709,18 @@ files = [
 ]
 
 [[package]]
+name = "types-jsonschema"
+version = "4.17.0.3"
+description = "Typing stubs for jsonschema"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-jsonschema-4.17.0.3.tar.gz", hash = "sha256:746aa466ffed9a1acc7bdbd0ac0b5e068f00be2ee008c1d1e14b0944a8c8b24b"},
+    {file = "types_jsonschema-4.17.0.3-py3-none-any.whl", hash = "sha256:c8d5b26b7c8da6a48d7fb1ce029b97e0ff6e74db3727efb968c69f39ad013685"},
+]
+
+[[package]]
 name = "types-pytz"
 version = "2021.3.8"
 description = "Typing stubs for pytz"
@@ -1873,4 +1885,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "aa779b0fcde19f11bc20dfcfb63b1d3be94fc4d38f5c3f84d7a16c65a54fb18a"
+content-hash = "ae0e74bb184ed77cafb18a5f84235b9b84937a6aef924b7e08fda82968e0b694"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ types-PyYAML = "^5.4.3"
 types-requests = "^2.28.11.5"
 black = "^22.10.0"
 
+[tool.poetry.group.dev.dependencies]
+types-jsonschema = "^4.17.0.3"
+
 [tool.coverage.run]
 omit = [
   "openstates/data/admin/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ os-people = 'openstates.cli.people:main'
 os-committees = 'openstates.cli.committees:main'
 os-us-to-yaml = 'openstates.cli.convert_us:main'
 os-scrape = 'openstates.cli.scrape:main'
+os-validate = 'openstates.cli.validate:main'
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
cc @NewAgeAirbender @bfossen-ce @elseagle for awareness

Wanted a command to be able to validate bill JSON files outside of the normal scrape process. This mostly copies some code from the [scrape base class](https://github.com/openstates/openstates-core/blob/main/openstates/scrape/base.py#L309) to use the already-defined schemas to validate an incoming JSON file.

Usage: `poetry run os-validate bill hb-1802.ocd-bill.json`