### PR TITLE
switch to a maintained stats library

### DIFF
--- a/openstates/utils/instrument.py
+++ b/openstates/utils/instrument.py
@@ -38,7 +38,7 @@ class Instrumentation(object):
         if not self.enabled:
             self.logger.debug("Stat emission is not enabled.")
             return
-        token: str = os.environ["OPENSTATES_STATS_AUTH_TOKEN"]
+        token: str = os.environ.get("OPENSTATES_STATS_AUTH_TOKEN", "")
         self._batch: List[Dict] = list()
         self.prefix: str = os.environ.get("STATS_PREFIX", "openstates_")
         self.endpoint: str = os.environ.get("STATS_ENDPOINT", "")

--- a/openstates/utils/instrument.py
+++ b/openstates/utils/instrument.py
@@ -1,23 +1,24 @@
 from ast import literal_eval
-import datetime
-import jwt
 import logging
 import logging.config
 import os
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 import time
+from influxdb_client import InfluxDBClient
+from influxdb_client.client.write_api import SYNCHRONOUS
+from influxdb_client.client.write.point import Point
+from influxdb_client.domain.write_precision import WritePrecision
 from typing import List, Dict
 
 from .. import settings
 
+"""
+Using these functions would look like:
 
-class MetricTypes:
-    CounterType = "count"
-    GaugeType = "gauge"
-    TimingType = "timing"
-    SetType = "set"
+from utils.instrument import Instrumentation
+stats = Instrumentation()
+stats.write_stats([{"metric": "objects", "fields"{ "scraped": 10}, "tags": {"jurisdiction": "ca"}])
+stats.close()
+"""
 
 
 class Instrumentation(object):
@@ -37,59 +38,22 @@ class Instrumentation(object):
         if not self.enabled:
             self.logger.debug("Stat emission is not enabled.")
             return
-        token: str = self._jwt_token()
+        token: str = os.environ["OPENSTATES_STATS_AUTH_TOKEN"]
         self._batch: List[Dict] = list()
         self.prefix: str = os.environ.get("STATS_PREFIX", "openstates_")
         self.endpoint: str = os.environ.get("STATS_ENDPOINT", "")
         if self.endpoint.endswith("/"):
             self.endpoint = self.endpoint.strip("/")
-        stats_retries: int = int(os.environ.get("STATS_RETRIES", 3))
-        self.batch_size: int = int(os.environ.get("STATS_BATCH_SIZE", 50))
-        self.default_tags: Dict = dict()
-        headers = {"Content-Type": "application/json"}
-        if token:
-            headers["X-JWT-Token"] = token
-        retry = Retry(
-            total=stats_retries,
-            read=stats_retries,
-            connect=stats_retries,
-            backoff_factor=0.3,
-            status_forcelist=(500, 502, 503, 504, 429, 104),
+        client = InfluxDBClient(
+            url=self.endpoint,
+            token=token,
+            org="openstates",
+            enable_gzip=True,
         )
-        adapter = HTTPAdapter(max_retries=retry)
-        self._stat_client = requests.Session()
-        self._stat_client.headers.update(headers)
-        # only mount https endpoint if we need it
-        if self.endpoint.startswith("https"):
-            self._stat_client.mount("https://", adapter)
-        else:
-            self._stat_client.mount("http://", adapter)
+        self.write_api = client.write_api(write_options=SYNCHRONOUS)
+        self.batch_size: int = int(os.environ.get("STATS_BATCH_SIZE", 50))
         self.logger.debug(
             f"Stats emission to {self.endpoint} configured with batch size: {self.batch_size}"
-        )
-
-    def _jwt_token(self) -> str:
-        """
-        Generate a JWT token from a consistent environment secret
-        Return empty strings when generation isn't possible.
-        """
-        if not self.enabled:
-            return ""
-        secret = os.environ.get("STATS_JWT_SECRET", "")
-        if not secret:
-            return ""
-        """
-        We need a pretty long expiration time for runs that take 12+ hours.
-        So we add the `exp` setting as 36 hours out. Should give us plenty of time.
-        """
-        return jwt.encode(
-            {
-                "id": "openstates",
-                "exp": datetime.datetime.now(tz=datetime.timezone.utc)
-                + datetime.timedelta(hours=36),
-            },
-            secret,
-            algorithm="HS256",
         )
 
     def _send_stats(self, force: bool = False) -> None:
@@ -107,49 +71,44 @@ class Instrumentation(object):
             if not self.endpoint:
                 self.logger.debug("No stats endpoint defined. Not emitting stats")
                 return
+            points = []
+            for m in self._batch:
+                if self.prefix:
+                    p = Point(f"{self.prefix}{m['metric']}")
+                else:
+                    p = Point(m["metric"])
+                p.time(m["timestamp"], WritePrecision.S)
+                """
+                use list comprehensions 'cause they're technically faster than for loops
+                But this is simply turning a dictionary of k=v pairs into tags/fields
+                in the point object
+                """
+                [p.tag(t, v) for t, v in m.get("tags", {}).items()]
+                [p.field(f, v) for f, v in m["fields"].items()]
+                points.append(p)
             self.logger.debug(f"Sending stats batch: {self._batch}")
             try:
-                self._stat_client.post(f"{self.endpoint}/batch", json=self._batch)
+                self.write_api("", record=points)
                 self._batch = list()
             except Exception as e:
                 self.logger.warning(
                     f"Failed to write {len(self._batch)} stats to {self.endpoint} :: {e}"
                 )
 
-    def _process_metric(
+    def write_stats(
         self,
-        metric_type: str,
-        metric: str,
-        tags: dict,
-        value: float,
-        sample_rate: float = 0,
+        metrics: List[Dict],
     ) -> None:
         """
         Ensure consistent formatting of data objects to add to batch for sending
+        Primarily, we'll force a timestamp on every metric in a consistent manner
         """
         if not self.enabled:
             return
-        # apply defaults only if not overridden
-        for k, v in self.default_tags.items():
-            if k not in tags:
-                tags[k] = v
-
-        """
-        Statsd http proxy specific formatting
-        """
-        # list(set()) to remove duplicates
-        tagstr = ",".join(list(set([f"{k}={v}" for k, v in tags.items()])))
-        data = {
-            "value": value,
-            "metric": f"{self.prefix}{metric}",
-            "metric_type": metric_type,
-            "tags": tagstr,
-        }
-        if sample_rate:
-            data["sampleRate"] = sample_rate
-        # End specific formatting
-
-        self._batch.append(data)
+        ts = int(time.time())
+        for m in metrics:
+            m["timestamp"] = ts
+            self._batch.append(m)
         """
         we attempt to send (without forcing) after
         adding each stat to make sure we emit
@@ -157,17 +116,6 @@ class Instrumentation(object):
         overloading the write endpoint with tiny writes
         """
         self._send_stats()
-
-    """
-    Wrapper scripts for easier sending
-
-    Using these functions would look like:
-
-    from utils.instrument import Instrumentation
-    stats = Instrumentation()
-    stats.send_gauge("objects_scraped", 10, [{"jurisdiction": "ca"}])
-    stats.close()
-    """
 
     def close(self) -> None:
         """
@@ -178,50 +126,3 @@ class Instrumentation(object):
         if not self.enabled:
             return
         self._send_stats(force=True)
-
-    def send_last_run(self, metric: str, tags: dict = {}) -> None:
-        """
-        Set a gauge with a current timestamp
-        Emulates a "last run time" feature simply
-        """
-        if not self.enabled:
-            return
-        self._process_metric(MetricTypes.GaugeType, metric, tags, int(time.time()))
-
-    def send_counter(
-        self,
-        metric: str,
-        value: float,
-        tags: dict = {},
-        sample_rate: float = 0,
-    ) -> None:
-        if not self.enabled:
-            return
-        self._process_metric(MetricTypes.CounterType, metric, tags, value, sample_rate)
-
-    def send_gauge(self, metric: str, value: float, tags: dict = {}) -> None:
-        """
-        Gauges aren't calculated, so don't require a sample rate
-        """
-        if not self.enabled:
-            return
-        self._process_metric(MetricTypes.GaugeType, metric, tags, value)
-
-    def send_timing(
-        self,
-        metric: str,
-        value: float,
-        tags: dict = {},
-        sample_rate: float = 0,
-    ) -> None:
-        if not self.enabled:
-            return
-        self._process_metric(MetricTypes.TimingType, metric, tags, value)
-
-    def send_set(self, metric: str, value: float, tags: dict = {}) -> None:
-        """
-        Sets (naturally) aren't calculated, so don't require a sample rate
-        """
-        if not self.enabled:
-            return
-        self._process_metric(MetricTypes.SetType, metric, tags, value)

--- a/openstates/utils/instrument.py
+++ b/openstates/utils/instrument.py
@@ -88,7 +88,7 @@ class Instrumentation(object):
                 points.append(p)
             self.logger.debug(f"Sending stats batch: {self._batch}")
             try:
-                self.write_api("", record=points)
+                self.write_api.write("", record=points)
                 self._batch = list()
             except Exception as e:
                 self.logger.warning(

--- a/poetry.lock
+++ b/poetry.lock
@@ -557,6 +557,30 @@ doc = ["sphinx"]
 test = ["mock (>=1.3.0)"]
 
 [[package]]
+name = "influxdb-client"
+version = "1.37.0"
+description = "InfluxDB 2.0 Python client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "influxdb_client-1.37.0-py3-none-any.whl", hash = "sha256:30b03888846fab6fb740936b1a08af24841b791cf1b99773e3894dd1d64edf2f"},
+    {file = "influxdb_client-1.37.0.tar.gz", hash = "sha256:01ac44d6a16a965ae2e0fa3238e2edeb147c11935a89b61439c9a752458001da"},
+]
+
+[package.dependencies]
+certifi = ">=14.05.14"
+python-dateutil = ">=2.5.3"
+reactivex = ">=4.0.4"
+setuptools = ">=21.0.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+async = ["aiocsv (>=1.2.2)", "aiohttp (>=3.8.1)"]
+ciso = ["ciso8601 (>=2.1.1)"]
+extra = ["numpy", "pandas (>=0.25.3)"]
+test = ["aioresponses (>=0.7.3)", "coverage (>=4.0.3)", "flake8 (>=5.0.3)", "httpretty (==1.0.5)", "jinja2 (==3.1.2)", "nose (>=1.3.7)", "pluggy (>=0.3.1)", "psutil (>=5.6.3)", "py (>=1.4.31)", "pytest (>=5.0.0)", "pytest-cov (>=3.0.0)", "pytest-timeout (>=2.1.0)", "randomize (>=0.13)", "sphinx (==1.8.5)", "sphinx-rtd-theme"]
+
+[[package]]
 name = "ipython"
 version = "7.34.0"
 description = "IPython: Productive Interactive Computing"
@@ -1549,6 +1573,20 @@ files = [
 ]
 
 [[package]]
+name = "reactivex"
+version = "4.0.4"
+description = "ReactiveX (Rx) for Python"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "reactivex-4.0.4-py3-none-any.whl", hash = "sha256:0004796c420bd9e68aad8e65627d85a8e13f293de76656165dffbcb3a0e3fb6a"},
+    {file = "reactivex-4.0.4.tar.gz", hash = "sha256:e912e6591022ab9176df8348a653fe8c8fa7a301f26f9931c9d8c78a650e04e8"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.1.1,<5.0.0"
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1932,4 +1970,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3bde81add7ed5d58bfba30ea035d0868af270b7327769138c8fa582c065fea83"
+content-hash = "535eaf1f55e7c47bfa8ed410fbde0c8132e7fca14eea403a6937bcb2c88f71d9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1809,6 +1809,20 @@ files = [
 ]
 
 [[package]]
+name = "types-influxdb-client"
+version = "1.37.0.0"
+description = "Typing stubs for influxdb-client"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-influxdb-client-1.37.0.0.tar.gz", hash = "sha256:05d0a9faccb5f532fa8aa354d3134e67662f6f9b8fedc5acf2d0288a7c4d4659"},
+    {file = "types_influxdb_client-1.37.0.0-py3-none-any.whl", hash = "sha256:ddaf6896dc22869a9a357718f8e07d1c676ab88c5aed5887f5709270caf04f42"},
+]
+
+[package.dependencies]
+types-urllib3 = "*"
+
+[[package]]
 name = "types-jsonschema"
 version = "4.17.0.10"
 description = "Typing stubs for jsonschema"
@@ -1970,4 +1984,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "535eaf1f55e7c47bfa8ed410fbde0c8132e7fca14eea403a6937bcb2c88f71d9"
+content-hash = "4ca23b11ba7cf90da3df2c2edc6f885e9119e4f86bf2b9e9e87df03773ea0fd1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ black = "^22.10.0"
 
 [tool.poetry.group.dev.dependencies]
 types-jsonschema = "^4.17.0.3"
+types-influxdb-client = "^1.37.0.0"
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ spatula = ">=0.8.9,<1.0"
 PyJWT = "^2.5.0"
 boto3 = "^1.26.61"
 us = "^3.1.1"
+influxdb-client = "^1.37.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"


### PR DESCRIPTION
Leveraging Plural's http->statsd proxy was a bad choice for a metrics library. Switching to influx format (as there is an actual maintained client and upstream documentation we can leverage).