### PR TITLE
InfluxDB bucket fix

### DIFF
--- a/openstates/utils/instrument.py
+++ b/openstates/utils/instrument.py
@@ -42,14 +42,13 @@ class Instrumentation(object):
         self._batch: List[Dict] = list()
         self.prefix: str = os.environ.get("STATS_PREFIX", "openstates_")
         self.endpoint: str = os.environ.get("STATS_ENDPOINT", "")
-        bucket: str = os.environ.get("STATS_BUCKET", "openstates")
+        self.bucket: str = os.environ.get("STATS_BUCKET", "openstates")
         if self.endpoint.endswith("/"):
             self.endpoint = self.endpoint.strip("/")
         client = InfluxDBClient(
             url=self.endpoint,
             token=token,
             org="openstates",
-            bucket=bucket,
             enable_gzip=True,
         )
         self.write_api = client.write_api(write_options=SYNCHRONOUS)
@@ -90,7 +89,7 @@ class Instrumentation(object):
                 points.append(p)
             self.logger.debug(f"Sending stats batch: {self._batch}")
             try:
-                self.write_api.write("", record=points)
+                self.write_api.write(self.bucket, record=points)
                 self._batch = list()
             except Exception as e:
                 self.logger.warning(

--- a/openstates/utils/instrument.py
+++ b/openstates/utils/instrument.py
@@ -42,12 +42,14 @@ class Instrumentation(object):
         self._batch: List[Dict] = list()
         self.prefix: str = os.environ.get("STATS_PREFIX", "openstates_")
         self.endpoint: str = os.environ.get("STATS_ENDPOINT", "")
+        bucket: str = os.environ.get("STATS_BUCKET", "openstates")
         if self.endpoint.endswith("/"):
             self.endpoint = self.endpoint.strip("/")
         client = InfluxDBClient(
             url=self.endpoint,
             token=token,
             org="openstates",
+            bucket=bucket,
             enable_gzip=True,
         )
         self.write_api = client.write_api(write_options=SYNCHRONOUS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.17.6"
+version = "6.17.7"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
While some influx-style endpoints don't require `bucket` (e.g. VictoriaMetrics), InfluxDB itself does.