### PR TITLE
DB settings: set application_name for better performance monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.17.8 - October 16, 2023
+
+* set application_name for better performance monitoring
+
 ## 6.17.5 - August 9, 2023
 
 * Add new bill statuses to validation

--- a/openstates/utils/django.py
+++ b/openstates/utils/django.py
@@ -9,6 +9,11 @@ def init_django() -> None:  # pragma: no cover
         "DATABASE_URL", "postgis://openstates:openstates@localhost/openstates"
     )
     DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
+    application_name = "os_core"
+    if "OPTIONS" not in DATABASES:
+        DATABASES["default"]["OPTIONS"] = {"application_name": application_name}
+    else:
+        DATABASES["default"]["OPTIONS"]["application_name"] = application_name
 
     conf.settings.configure(
         conf.global_settings,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.17.7"
+version = "6.17.8"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
*should* segment DB performance in AWS monitoring, though I am not sure how to test this one directly. But it is using the same Django setup stuff (I think) as openstates.org does, so I expect it will work.