### PR TITLE
People: add distinct mailing classification options to offices

### DIFF
--- a/openstates/models/people.py
+++ b/openstates/models/people.py
@@ -85,7 +85,9 @@ EXECUTIVE_ROLES = (
 
 class OfficeType(str, Enum):
     DISTRICT = "district"
+    DISTRICT_MAIL = "district-mail"
     CAPITOL = "capitol"
+    CAPITOL_MAIL = "capitol-mail"
     PRIMARY = "primary"
 
 

--- a/openstates/models/people.py
+++ b/openstates/models/people.py
@@ -89,6 +89,7 @@ class OfficeType(str, Enum):
     CAPITOL = "capitol"
     CAPITOL_MAIL = "capitol-mail"
     PRIMARY = "primary"
+    HOME = "home"
 
 
 class PersonIdBlock(BaseModel):


### PR DESCRIPTION
Adds new classification options for an `office`: `district-mail` and `capitol-mail`.

Plural pulled in a new data source for People, that helps us add some data points that were not possible to scrape, and also still allows us to publish public data about elected officials. 

This new dataset includes office addresses in some jurisdictions that are distinct between the physical location of the office and the mailing address. Adding these new classifications would allow us to have both data points in the People repo (otherwise those classifications are deemed invalid).

**Possible downside**: could move some data that was previously classified as `district` or `capitol` to one of the new classifications. Client code may not know how to handle these new classifications.

**Alternative**: leave the "mailing" addresses out of the People repo.
