### PR TITLE
Stop validating repeat phone numbers on offices

### DIFF
--- a/openstates/data/models/people_orgs.py
+++ b/openstates/data/models/people_orgs.py
@@ -286,8 +286,11 @@ class PersonName(RelatedBase):
 
 OFFICE_CHOICES = (
     ("district", "District Office"),
+    ("district-mail", "District Mailing Address")
     ("capitol", "Capitol Office"),
+    ("capitol-mail", "Capitol Mailing Address")
     ("primary", "Primary Office"),
+    ("home", "Home")
 )
 
 

--- a/openstates/data/models/people_orgs.py
+++ b/openstates/data/models/people_orgs.py
@@ -288,9 +288,9 @@ OFFICE_CHOICES = (
     ("district", "District Office"),
     ("district-mail", "District Mailing Address")
     ("capitol", "Capitol Office"),
-    ("capitol-mail", "Capitol Mailing Address")
+    ("capitol-mail", "Capitol Mailing Address"),
     ("primary", "Primary Office"),
-    ("home", "Home")
+    ("home", "Home"),
 )
 
 

--- a/openstates/data/models/people_orgs.py
+++ b/openstates/data/models/people_orgs.py
@@ -286,7 +286,7 @@ class PersonName(RelatedBase):
 
 OFFICE_CHOICES = (
     ("district", "District Office"),
-    ("district-mail", "District Mailing Address")
+    ("district-mail", "District Mailing Address"),
     ("capitol", "Capitol Office"),
     ("capitol-mail", "Capitol Mailing Address"),
     ("primary", "Primary Office"),

--- a/openstates/utils/people/lint_people.py
+++ b/openstates/utils/people/lint_people.py
@@ -94,7 +94,7 @@ def validate_offices(person: Person) -> list[str]:
     for office in person.offices:
         type_counter[office.classification] += 1
         for key, value in office.dict().items():
-            if key == "classification" or not value:
+            if key == "classification" or key == "voice" or key == "fax" or not value:
                 continue
             # reverse lookup to see if we've used this phone number/etc. before
             location_str = f"{office.classification} {key}"

--- a/openstates/utils/tests/test_lint.py
+++ b/openstates/utils/tests/test_lint.py
@@ -172,15 +172,6 @@ def test_validate_roles_retired(roles, expected):
             ],
             [],
         ),
-        (
-            [
-                {"classification": "district", "voice": "123-444-4444"},
-                {"classification": "capitol", "voice": "123-444-4444"},
-            ],
-            [
-                "Value '123-444-4444' used multiple times: district voice and capitol voice"
-            ],
-        ),
     ],
 )
 def test_validate_offices(offices, expected):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.18.0"
+version = "6.18.1"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Running into a fair number of `Value 'PHONE_NUMBER' used multiple times: district voice and district voice` validation errors, and I just don't see the value in preventing a phone number from being used on more than one office, especially in the age of cell phones.