### PR TITLE
ME: add tribal representative district to metadata

### DIFF
--- a/openstates/metadata/data/me.py
+++ b/openstates/metadata/data/me.py
@@ -1,4 +1,4 @@
-from ..models import State, Chamber, simple_numbered_districts
+from ..models import State, Chamber, District, simple_numbered_districts
 
 ME = State(
     name="Maine",
@@ -22,7 +22,8 @@ ME = State(
         title="Representative",
         districts=simple_numbered_districts(
             "ocd-division/country:us/state:me", "lower", 151
-        ),
+        ) + [District("Passamaquoddy Tribe", "lower",
+                     f"ocd-division/country:us/state:me/sldl:passamaquoddy-tribe")],
     ),
     upper=Chamber(
         chamber_type="upper",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.18.1"
+version = "6.18.2"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Adds a district to represent the non-voting but official representative from the Passamaquoddy Tribe in Maine.

https://legislature.maine.gov/house-independents/house-independents/9453