### PR TITLE
Docs: make release instructions more explicit/specific, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 6.18.2
+
+* Maine (ME): add a tribal representative district to the jurisdiction metadata
+
+## 6.18.1 - January 24, 2024
+
+* Stop validating the repeated use of the same phone number in People offices data
+
+## 6.18.0 - January 24, 2024
+
+* People: add distinct mailing classification options (district-mail, capitol-mail) and home classification to offices
+* Docs: Add debug instructions for the update command by @jessemortenson in #119
+
 ## 6.17.9 - October 26, 2023
 
 * allow postimport hook to be skipped in os-update command

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This repository contains the Open States data model and scraper backend.
 * [Code of Conduct](https://docs.openstates.org/en/latest/contributing/code-of-conduct.html)
 * [Contributing to Open States](https://docs.openstates.org/contributing/)
 
+## Release steps
+
+See [RELASE.md](./RELEASE.md)
+
 ## Debugging openstates-core code
 
 ### Update command / scrapers

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,13 @@
 Release Process:
 
-* bump version in pyproject.toml
-* update changelog
-* tag & push tag
-* poetry publish --build
+* bump version in `pyproject.toml`
+* update `CHANGELOG.md`
+* once code is merged into `main`
+  * Create a new Release in Github
+    * Target `main`
+    * Create a new tag that matches new version from `pyproject.toml`
+  * By creating a tag, this triggers the [release workflow](./.github/workflows/release.yml) which builds and
+    pushes the new version to PyPi
 
 Post-Release updates:
 


### PR DESCRIPTION
Last week I checked README and didn't see release instructions, and forgot/didn't notice that there was a separate RELEASE doc, smh. So I'm trying to make that a little more obvious in the README, and adjusted the release instructions to be more specific.