### PR TITLE
Update queries to filter by all other names

### DIFF
--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -14,5 +14,5 @@ class OrganizationImporter(BaseImporter):
 
         name = spec.pop("name", None)
         if name:
-            return Q(**spec) & (Q(other_names__0__name=name) | Q(name=name))
+            return Q(**spec) & (Q(other_names__name=name) | Q(name=name))
         return spec


### PR DESCRIPTION
Update organization import query to filter by  all available instead of just the first available `other_names`. This will help expand our search pool as we start adding more `other_names` to committees across jurisdictions.