### PR TITLE
Update organization other_names lookup

### DIFF
--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -14,5 +14,7 @@ class OrganizationImporter(BaseImporter):
 
         name = spec.pop("name", None)
         if name:
-            return Q(**spec) & (Q(other_names__0__name=name) | Q(name=name))
+            return Q(**spec) & (
+                Q(name=name) | Q(other_names__contains=[{"name": name}])
+            )
         return spec


### PR DESCRIPTION
This updates the query for `opencivicdata_organization.other_names`. The column is a JSON field that contains a list of objects. We need to lookup if any of the objects' name matches our `name`