### PR TITLE
Use incoming Chamber in resolve_person() to improve sponsorship matches

### DIFF
--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -536,6 +536,12 @@ class BaseImporter:
 
         # turn spec into DB query
         spec = get_pseudo_id(psuedo_person_id)
+
+        # if chamber is included in pseudo_person_id, use that as org_classification
+        if "chamber" in spec and org_classification is None:
+            org_classification = spec["chamber"]
+            del spec["chamber"]
+
         if list(spec.keys()) == ["name"]:
             # if we're just resolving on name, include other names and family name
             name = spec["name"]

--- a/openstates/scrape/bill.py
+++ b/openstates/scrape/bill.py
@@ -109,7 +109,7 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
         entity_type,
         primary,
         *,
-        chamber=None,
+        chamber=None,  # upper, lower or legislature
         entity_id=None,
     ):
         sp = {
@@ -124,7 +124,10 @@ class Bill(SourceMixin, AssociatedLinkMixin, BaseModel):
         # overwrite the id that exists
         if entity_type:
             if not entity_id:
-                entity_id = _make_pseudo_id(name=name)
+                if chamber is not None:
+                    entity_id = _make_pseudo_id(name=name, chamber=chamber)
+                else:
+                    entity_id = _make_pseudo_id(name=name)
             sp[entity_type + "_id"] = entity_id
         if sp in self.sponsorships:
             warnings.warn(f"duplicate sponsor {sp}", RuntimeWarning)

--- a/openstates/scrape/tests/test_bill_scrape.py
+++ b/openstates/scrape/tests/test_bill_scrape.py
@@ -124,7 +124,7 @@ def test_add_sponsor():
     )
     assert len(b.sponsorships) == 1
     assert b.sponsorships[0] == {
-        "person_id": '~{"name": "Joe Bleu"}',
+        "person_id": '~{"chamber": "upper", "name": "Joe Bleu"}',
         "name": "Joe Bleu",
         "classification": "Author",
         "entity_type": "person",


### PR DESCRIPTION
I'm going to call this a draft for now. I have tested with 4 jurisdictions and confirmed that resolve_person() matching does not get WORSE, but haven't actually found a test sample where it makes it better yet. Will want to hunt for that before confirming a merge. But want to share to make sure my logic is going in the right direction.