### PR TITLE
Events to Bills: Add -1 Day to Match Query

### DIFF
--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -4,6 +4,7 @@ import glob
 import json
 import logging
 import typing
+from dateutils.parser import *
 from django.db.models import Q, Model
 from django.db.models.signals import post_save
 from .. import settings
@@ -181,6 +182,21 @@ class BaseImporter:
             return ids.pop()
         elif len(ids) == 0:
             self.error(f"could not resolve bill id {bill_id} {date}, no matches")
+            new_date = parse(date)+relativedelta(days=4)
+            objects = Bill.objects.filter(
+                Q(legislative_session__end_date__gte=new_date)
+                | Q(legislative_session__end_date=""),
+                legislative_session__start_date__lte=new_date,
+                legislative_session__jurisdiction_id=self.jurisdiction_id,
+                identifier=bill_id,
+            )
+            ids = {each.id for each in objects}
+            if len(ids) == 1:
+                return ids.pop()
+            else:
+                self.error(
+                    f"could not resolve bill with fluffed date {bill_id} {new_date}, {len(ids)} matches"
+                )
         else:
             self.error(
                 f"could not resolve bill id {bill_id} {date}, {len(ids)} matches"

--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -171,7 +171,7 @@ class BaseImporter:
 
         # move the start_date up a bit in case the event is on the last day of a session to compare with end_date
         date = datetime.fromisoformat(date)
-        new_date = date + timedelta(days=-1)
+        new_date = date - timedelta(days=1)
 
         objects = Bill.objects.filter(
             Q(legislative_session__end_date__gte=new_date)
@@ -185,23 +185,7 @@ class BaseImporter:
         if len(ids) == 1:
             return ids.pop()
         elif len(ids) == 0:
-            self.warning(f"could not resolve {bill_id} {new_date}, no matches so will retry with a week earlier")
-            week_date = date + timedelta(days=-7)
-            objects = Bill.objects.filter(
-                Q(legislative_session__end_date__gte=week_date)
-                | Q(legislative_session__end_date=""),
-                legislative_session__start_date__lte=date,
-                legislative_session__jurisdiction_id=self.jurisdiction_id,
-                identifier=bill_id,
-            )
-            ids = {each.id for each in objects}
-            if len(ids) == 1:
-                self.info(f"resolved bill id {bill_id} with tweaked start_date {week_date}")
-                return ids.pop()
-            else:
-                self.error(
-                    f"could not resolve bill with tweaked date {bill_id} {new_date}, {len(ids)} matches"
-                )
+            self.error(f"could not resolve bill id {bill_id} {date}, no matches")
         else:
             self.error(
                 f"could not resolve bill id {bill_id} {date}, {len(ids)} matches"

--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -15,6 +15,6 @@ class OrganizationImporter(BaseImporter):
         name = spec.pop("name", None)
         if name:
             return Q(**spec) & (
-                Q(name=name) | Q(other_names__contains=[{"name": name}])
+                Q(name__iexact=name) | Q(other_names__iexact=[{"name": name}])
             )
         return spec

--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -15,6 +15,6 @@ class OrganizationImporter(BaseImporter):
         name = spec.pop("name", None)
         if name:
             return Q(**spec) & (
-                Q(name__iexact=name) | Q(other_names__iexact=[{"name": name}])
+                Q(name=name) | Q(other_names__contains=[{"name": name}])
             )
         return spec

--- a/openstates/importers/tests/test_event_importer.py
+++ b/openstates/importers/tests/test_event_importer.py
@@ -32,7 +32,7 @@ def create_other_jurisdiction():
 def ge():
     event = ScrapeEvent(
         name="America's Birthday",
-        start_date="2014-07-04T05:00Z",
+        start_date="2014-07-04T05:00:00+00:00",
         location_name="America",
         all_day=True,
     )


### PR DESCRIPTION
If an Event is scheduled for the last day of a session, we'd miss the match to a bill because the `start_date` of the Event is the same as the date the Legislative session ended. I've verified that this catches & actually matches Events with Bills that are on the last day of the session with AK, this would also capture Bills added to events that take place just before session start if there are discussions on prefiled bills.