### PR TITLE
Case Insentitive committee name matching

### DIFF
--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -15,7 +15,7 @@ class OrganizationImporter(BaseImporter):
         name = spec.pop("name", None)
         if name:
             # __icontains doesn't work for JSONField ArrayField
-            # so other_names follows "title" naming pattern
+            # so other_name_lowercase_on follows "title" naming pattern
             other_name_lowercase_on = name.title().replace(" On ", " on ")
             return Q(**spec) & (
                 Q(name__iexact=name)

--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -15,6 +15,6 @@ class OrganizationImporter(BaseImporter):
         name = spec.pop("name", None)
         if name:
             return Q(**spec) & (
-                Q(name=name) | Q(other_names__contains=[{"name": name}])
+                Q(name_iexact=name) | Q(other_names__icontains=[{"name": name}])
             )
         return spec

--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -14,7 +14,10 @@ class OrganizationImporter(BaseImporter):
 
         name = spec.pop("name", None)
         if name:
+            # __icontains doesn't work for JSONField ArrayField
+            # so other_names follows "title" naming pattern
+            other_names = name.title().replace(" On ", " on ")
             return Q(**spec) & (
-                Q(name_iexact=name) | Q(other_names__icontains=[{"name": name}])
+                Q(name__iexact=name) | Q(other_names__contains=[{"name": other_names}])
             )
         return spec

--- a/openstates/importers/organizations.py
+++ b/openstates/importers/organizations.py
@@ -16,8 +16,9 @@ class OrganizationImporter(BaseImporter):
         if name:
             # __icontains doesn't work for JSONField ArrayField
             # so other_names follows "title" naming pattern
-            other_names = name.title().replace(" On ", " on ")
+            other_name_lowercase_on = name.title().replace(" On ", " on ")
             return Q(**spec) & (
-                Q(name__iexact=name) | Q(other_names__contains=[{"name": other_names}])
+                Q(name__iexact=name)
+                | Q(other_names__contains=[{"name": other_name_lowercase_on}])
             )
         return spec


### PR DESCRIPTION
Update matching query to case insensitive.  `__icontains` doesn't work for `JSONField` and `ArrayField` so modified other_names to follow "title" naming pattern  which is the likely pattern of `other_names` in the DB.