### PR TITLE
Update build-system in pyproject to a modern value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ omit = [
 ]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I could not install openstates-core via the `poetry ... --editable` route until I made this change (found it on a stackoverflow or something). Seems like the old `build-system` value has been here quite a while and is out of date.