### PR TITLE
Fix import bug caused by 'extras' property on legislative session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 6.20.8 - Oct 18, 2024q
+## 6.20.9 - Nov 4, 2024
+
+* Fix bug with import caused by newish "extras" field on scraper
+
+## 6.20.8 - Oct 18, 2024
 
 * Improve resolve bill to capture at least the most recent session
 

--- a/openstates/importers/jurisdiction.py
+++ b/openstates/importers/jurisdiction.py
@@ -19,4 +19,6 @@ class JurisdictionImporter(BaseImporter):
     def prepare_for_db(self, data: _JsonDict) -> _JsonDict:
         for s in data["legislative_sessions"]:
             s.pop("_scraped_name", None)
+            if "extras" in s:
+                s.pop("extras")
         return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.20.8"
+version = "6.20.9"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Fixes error `openstates.exceptions.DataImportError: LegislativeSession() got an unexpected keyword argument 'extras' while importing` for new sessions during import.