### PR TITLE
Revert "Events: importer matches incoming events to NON-deleted existing events"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 6.20.11 - Nov 7, 2024
-
-* Events import: ignore deleted events when matching incoming events to existing.
-
 ## 6.20.10 - Nov 7, 2024
 
 * Add additional log info re: archiving scrape files to cloud storage

--- a/openstates/importers/events.py
+++ b/openstates/importers/events.py
@@ -63,7 +63,6 @@ class EventImporter(BaseImporter):
                 "start_date": event["start_date"],
                 "end_date": event["end_date"],
                 "jurisdiction_id": self.jurisdiction_id,
-                "deleted": False,  # no need to match existing deleted events if this is new/incoming
             }
         return self.model_class.objects.get(**spec)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.20.11"
+version = "6.20.10"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Reverts openstates/openstates-core#153

I think my "solution" here was heavy-handed, and given that there is a test for the functionality I think safer to back out of it.