### PR TITLE
Stop checking for duplicates in imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.20.14 - Jan 27, 2025
+
+* Allow duplicate items to be imported in import via new runtime flag --allow_duplicates
+
 ## 6.20.13 - Dec 27, 2024
 
 * Sanitize phone number for US people scrape.

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -264,11 +264,11 @@ def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
         logger.info("import jurisdictions...")
         report.update(juris_importer.import_directory(datadir))
         logger.info("import bills...")
-        report.update(bill_importer.import_directory(datadir))
+        report.update(bill_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
         logger.info("import vote events...")
-        report.update(vote_event_importer.import_directory(datadir))
+        report.update(vote_event_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
         logger.info("import events...")
-        report.update(event_importer.import_directory(datadir))
+        report.update(event_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
         DatabaseJurisdiction.objects.filter(id=juris.jurisdiction_id).update(
             latest_bill_update=datetime.datetime.utcnow()
         )
@@ -519,6 +519,12 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
         action="store_false",
         dest="strict",
         help="skip validation on save",
+    )
+    parser.add_argument(
+        "--allow_duplicates",
+        action="store_true",
+        dest="allow_duplicates",
+        help="Skip throwing a DuplicateItemError, instead all import of duplicate items",
     )
     parser.add_argument(
         "--fastmode", action="store_true", help="use cache and turn off throttling"

--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -369,9 +369,8 @@ class BaseImporter:
 
         # obj existed, check if we need to do an update
         if obj:
-            # JKM: no longer checking for duplacates! Too many import errors
-            # and they are time consuming to track down.
-            # what is the worst thing that can happen if we overwrite dupe data?
+            # If --allow_duplicates flag is set on client CLI command
+            # then we ignore duplicates instead of raising an exception
             if not allow_duplicates and obj.id in self.json_to_db_id.values():
                 raise DuplicateItemError(data, obj, related.get("sources", []))
             elif allow_duplicates and obj.id in self.json_to_db_id.values():

--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -369,8 +369,11 @@ class BaseImporter:
 
         # obj existed, check if we need to do an update
         if obj:
-            if obj.id in self.json_to_db_id.values():
-                raise DuplicateItemError(data, obj, related.get("sources", []))
+            # JKM: no longer checking for duplacates! Too many import errors
+            # and they are time consuming to track down.
+            # what is the worst thing that can happen if we overwrite dupe data?
+            # if obj.id in self.json_to_db_id.values():
+            #     raise DuplicateItemError(data, obj, related.get("sources", []))
             # check base object for changes
             for key, value in data.items():
                 if getattr(obj, key) != value:

--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -9,7 +9,7 @@ from django.db.models import Q, Model
 from django.db.models.signals import post_save
 from .. import settings
 from ..data.models import LegislativeSession, Person, Bill
-from ..exceptions import DuplicateItemError, UnresolvedIdError, DataImportError
+from ..exceptions import UnresolvedIdError, DataImportError
 from ..utils import get_pseudo_id, utcnow
 from ._types import _ID, _JsonDict, _RelatedModels, _TransformerMapping
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.20.13"
+version = "6.20.14"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Status quo data imports always fail if there is one or more duplicate items yielded by the scraper. Ideally scrapes do not emit duplicates, but due to the vagaries of our source sites, it can be time consuming in some cases to root them out. And in many cases the duplicates are identical, so doing extra imports of the same data does not cause harm. In those cases, eliminating the duplicates is actually pretty low priority work. But the fact that the import is halted turns it into high priority work.

This change introduces a runtime flag `--allow_duplicates` that can be used to change the behavior to warn only on duplicate items.