### PR TITLE
Add informal-passage action classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.21.6 - Apr 21, 2025
+* Add informal passage to bill action classification
+
 ## 6.21.5 - Apr 9, 2025
 * Add to Docker workflow to publish to internal repo as well
 

--- a/openstates/data/common.py
+++ b/openstates/data/common.py
@@ -92,6 +92,7 @@ BILL_ACTION_CLASSIFICATION_CHOICES = (
     ("reading-2", "Second Reading"),
     ("reading-3", "Third Reading"),
     ("passage", "Passage"),
+    ("informal-passage", "Informal Passage"),
     ("failure", "Passage Failure"),
     ("withdrawal", "Withdrawal"),
     ("substitution", "Substitution"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.21.5"
+version = "6.21.6"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
Adding `informal-passage` bill action classification. This affects  AZ  where Committee of the whole informally vote on a bill without 3rd reading.