### PR TITLE
Add HTTP resilience mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.23.0 - May 21, 2025
+* Introduces --http-resilience flag for the os-update command which runs a scraper with techniques to avoid getting
+  disconnected from a source server.
+
 ## 6.22.3 - May 14, 2025
 * Use DAG run start time for archiving scrape output
 

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -90,6 +90,7 @@ def do_scrape(
         fastmode=args.fastmode,
         realtime=args.realtime,
         file_archiving_enabled=args.archive,
+        http_resilience_mode=args.http_resilience,
     )
     report["jurisdiction"] = jscraper.do_scrape()
     stats.write_stats(
@@ -129,6 +130,7 @@ def do_scrape(
                     fastmode=args.fastmode,
                     realtime=args.realtime,
                     file_archiving_enabled=args.archive,
+                    http_resilience_mode=args.http_resilience,
                 )
                 partial_report = scraper.do_scrape(**scrape_args, session=session)
                 last_scrape_end_datetime = partial_report["end"]
@@ -163,6 +165,7 @@ def do_scrape(
                 fastmode=args.fastmode,
                 realtime=args.realtime,
                 file_archiving_enabled=args.archive,
+                http_resilience_mode=args.http_resilience,
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
             last_scrape_end_datetime = report[scraper_name]["end"]
@@ -553,6 +556,13 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
         help="scraper retry wait",
         type=int,
         dest="SCRAPELIB_RETRY_WAIT_SECONDS",
+    )
+
+    # HTTP resilience mode: enable random delays, user agents, more complicated retries
+    parser.add_argument(
+        "--http-resilience",
+        action="store_true",
+        help="enable HTTP resilience mode, defaults to false",
     )
 
     # realtime mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.22.3"
+version = "6.23.0"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
This is a WIP draft of porting the HTTP resilience features that @elseagle introduced (originally in the FL scraper, later I re-used in IA scraper) up into openstates-core. The goal is to turn these features into a toggleable behavior instead of something that needs to be grafted onto scrapers one-by-one.

This is not sufficiently tested yet. I'm running an IA scrape (with the grafted version removed from scraper code), and will want to do the same with FL. And then test with some other scrapers to make sure I haven't regressed something.

cc @showerst and @alexobaseki 