### PR TITLE
Incrementally save scrape output

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -169,6 +169,7 @@ def do_scrape(
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
             session = scrape_args.get("session", "")
+            scraper.archive_to_gcs_real_time(force_flush=True)
             if session:
                 stats.write_stats(
                     [
@@ -237,11 +238,15 @@ def archive_to_cloud_storage(
             blob = bucket.blob(blob_name)
             blob.upload_from_filename(file_path)
 
-        logger.info(f"Completed archive to Google Cloud Storage, {files_count} files "
-                    f"were uploaded to {destination_prefix}.")
+        logger.info(
+            f"Completed archive to Google Cloud Storage, {files_count} files "
+            f"were uploaded to {destination_prefix}."
+        )
 
     except Exception as e:
-        logger.warning(f"An error occurred during the attempt to archive files to Google Cloud Storage: {e}")
+        logger.warning(
+            f"An error occurred during the attempt to archive files to Google Cloud Storage: {e}"
+        )
 
 
 def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
@@ -266,11 +271,23 @@ def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
         logger.info("import jurisdictions...")
         report.update(juris_importer.import_directory(datadir))
         logger.info("import bills...")
-        report.update(bill_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
+        report.update(
+            bill_importer.import_directory(
+                datadir, allow_duplicates=args.allow_duplicates
+            )
+        )
         logger.info("import vote events...")
-        report.update(vote_event_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
+        report.update(
+            vote_event_importer.import_directory(
+                datadir, allow_duplicates=args.allow_duplicates
+            )
+        )
         logger.info("import events...")
-        report.update(event_importer.import_directory(datadir, allow_duplicates=args.allow_duplicates))
+        report.update(
+            event_importer.import_directory(
+                datadir, allow_duplicates=args.allow_duplicates
+            )
+        )
         DatabaseJurisdiction.objects.filter(id=juris.jurisdiction_id).update(
             latest_bill_update=datetime.datetime.utcnow()
         )

--- a/openstates/settings.py
+++ b/openstates/settings.py
@@ -3,9 +3,7 @@ from .utils import transformers
 
 # settings for realtime flag
 S3_REALTIME_BASE = os.environ.get("S3_REALTIME_BASE")  # e.g 's3://realtime-bucket'
-SQS_QUEUE_URL = os.environ.get(
-    "SQS_QUEUE_URL"
-)
+SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL")
 
 # scrape settings
 
@@ -27,12 +25,18 @@ SCRAPED_DATA_DIR = os.path.join(os.getcwd(), "_data")
 IMPORT_TRANSFORMERS = {
     "bill": {
         "identifier": transformers.fix_bill_id,
-        "documents": {"note": transformers.truncate_300},  # TODO remove when db migration done
-        "versions": {"note": transformers.truncate_300},  # TODO remove when db migration done
+        "documents": {
+            "note": transformers.truncate_300
+        },  # TODO remove when db migration done
+        "versions": {
+            "note": transformers.truncate_300
+        },  # TODO remove when db migration done
     },
     "event": {
-        "media": {"note": transformers.truncate_300},  # TODO remove when db migration done
-    }
+        "media": {
+            "note": transformers.truncate_300
+        },  # TODO remove when db migration done
+    },
 }
 
 # Django settings
@@ -59,3 +63,6 @@ LOGGING = {
         "boto": {"handlers": ["default"], "level": "WARN", "propagate": False},
     },
 }
+
+# Realtime Upload
+DATA_CLASSES = ["bill", "event", "vote_event", "jurisdiction", "organization"]


### PR DESCRIPTION
Incrementally saving scrape output to GCS. 
* Save each object by appending to a JSONL file during the archive interval(currently set to 15 minutes)
* Upload JSONL file by data class and local file.
* force archive at the end of a scrape to upload any file that wasn't uploading.