### PR TITLE
Made realtime mode non-exclusive with normal import for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.24.2 - Jun 24, 2025
+* Change real-time mode to be non-exclusive while we work on refactoring it.
+  The --realtime flag will no longer prevent normal import nor prevent the
+  --archive logic from working.
+
 ## 6.24.1 - Jun 22, 2025
 * Update file path for real-time upload. 
 

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -205,8 +205,8 @@ def do_scrape(
                 )
 
     # optionally upload scrape output to cloud storage
-    # but do not archive if realtime mode enabled, as realtime mode has its own archiving process
-    if args.archive and not args.realtime:
+    # archive and realtime BOTH coexist for now, as we refactor realtime
+    if args.archive:  # and not args.realtime:
         archive_to_cloud_storage(datadir, juris, last_scrape_datetime)
 
     return report
@@ -422,8 +422,8 @@ def do_update(
                     }
                 ]
             )
-        # we skip import in realtime mode since this happens via the lambda function
-        if "import" in args.actions and not args.realtime:
+        # realtime and normal import coexist for now as we refactor realtime
+        if "import" in args.actions:  # and not args.realtime:
             report["import"] = do_import(juris, args)
             stats.write_stats(
                 [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.24.1"
+version = "6.24.2"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
We are in the midst of doing a refactor around --realtime mode, and while that is in progress it needs to no longer be exclusive of normal import and archive logic. With this change, enabling --realtime will no longer disable those other modes.