### PR TITLE
Resolve duplicate legislators in state-specific search

### DIFF
--- a/openstates/data/models/people_orgs.py
+++ b/openstates/data/models/people_orgs.py
@@ -156,7 +156,7 @@ class PersonQuerySet(QuerySet):
         if state:
             people = people.filter(
                 memberships__organization__jurisdiction_id=abbr_to_jid(state)
-            )
+            ).distinct()
         return people
 
 


### PR DESCRIPTION
Use .distinct() method to return unique legislators in state-specific search