### PR TITLE
Add executive role types for people imports

### DIFF
--- a/openstates/models/people.py
+++ b/openstates/models/people.py
@@ -68,6 +68,10 @@ class RoleType(str, Enum):
     MAYOR = "mayor"
     SOS = "secretary of state"
     CHIEF_ELECTION_OFFICER = "chief election officer"
+    TREASURER = "treasurer"
+    AUDITOR = "auditor"
+    COMPTROLLER = "comptroller"
+    ATTORNEY_GENERAL = "attorney_general"
 
 
 LEGISLATIVE_ROLES = (
@@ -81,6 +85,10 @@ EXECUTIVE_ROLES = (
     RoleType.MAYOR,
     RoleType.CHIEF_ELECTION_OFFICER,
     RoleType.SOS,
+    RoleType.TREASURER,
+    RoleType.AUDITOR,
+    RoleType.COMPTROLLER,
+    RoleType.ATTORNEY_GENERAL,
 )
 
 

--- a/openstates/models/tests/test_models.py
+++ b/openstates/models/tests/test_models.py
@@ -213,6 +213,12 @@ def test_role_conditional_requires():
         end_date="2016",
         jurisdiction=VALID_JURISDICTION_ID,
     )
+    assert Role(
+        type=RoleType.ATTORNEY_GENERAL,
+        start_date="2010",
+        end_date="2016",
+        jurisdiction=VALID_JURISDICTION_ID,
+    )
 
     with pytest.raises(ValidationError):
         assert Role(
@@ -222,6 +228,12 @@ def test_role_conditional_requires():
     with pytest.raises(ValidationError):
         assert Role(
             type=RoleType.GOVERNOR,
+            start_date="2010",
+            jurisdiction=VALID_JURISDICTION_ID,
+        )
+    with pytest.raises(ValidationError):
+        assert Role(
+            type=RoleType.TREASURER,
             start_date="2010",
             jurisdiction=VALID_JURISDICTION_ID,
         )

--- a/openstates/models/tests/test_models.py
+++ b/openstates/models/tests/test_models.py
@@ -200,6 +200,31 @@ def test_role_basics():
         )
 
 
+@pytest.mark.parametrize(
+    "role_type",
+    [
+        RoleType.TREASURER,
+        RoleType.AUDITOR,
+        RoleType.COMPTROLLER,
+        RoleType.ATTORNEY_GENERAL,
+    ],
+)
+def test_new_executive_roles_require_end_date(role_type):
+    assert Role(
+        type=role_type,
+        start_date="2010",
+        end_date="2016",
+        jurisdiction=VALID_JURISDICTION_ID,
+    )
+
+    with pytest.raises(ValidationError):
+        assert Role(
+            type=role_type,
+            start_date="2010",
+            jurisdiction=VALID_JURISDICTION_ID,
+        )
+
+
 def test_role_conditional_requires():
     assert Role(
         type=RoleType.UPPER,
@@ -213,12 +238,6 @@ def test_role_conditional_requires():
         end_date="2016",
         jurisdiction=VALID_JURISDICTION_ID,
     )
-    assert Role(
-        type=RoleType.ATTORNEY_GENERAL,
-        start_date="2010",
-        end_date="2016",
-        jurisdiction=VALID_JURISDICTION_ID,
-    )
 
     with pytest.raises(ValidationError):
         assert Role(
@@ -228,12 +247,6 @@ def test_role_conditional_requires():
     with pytest.raises(ValidationError):
         assert Role(
             type=RoleType.GOVERNOR,
-            start_date="2010",
-            jurisdiction=VALID_JURISDICTION_ID,
-        )
-    with pytest.raises(ValidationError):
-        assert Role(
-            type=RoleType.TREASURER,
             start_date="2010",
             jurisdiction=VALID_JURISDICTION_ID,
         )

--- a/openstates/utils/people/to_database.py
+++ b/openstates/utils/people/to_database.py
@@ -12,6 +12,17 @@ DataDict = dict[str, typing.Any]
 DjangoModel = typing.Any
 DjangoModelInstance = typing.Any
 
+EXECUTIVE_ROLE_TITLES = {
+    "governor": "Governor",
+    "lt_governor": "Lieutenant Governor",
+    "secretary of state": "Secretary of State",
+    "chief election officer": "Chief Election Officer",
+    "treasurer": "Treasurer",
+    "auditor": "Auditor",
+    "comptroller": "Comptroller",
+    "attorney_general": "Attorney General",
+}
+
 
 class CancelTransaction(Exception):
     pass
@@ -166,8 +177,8 @@ def load_person(data: Person) -> tuple[bool, bool]:
                 role_name = "Mayor"
             org_type = "executive"
             use_district = False
-        elif role.type in ("secretary of state", "chief election officer"):
-            role_name = role.type.title()
+        elif role.type in EXECUTIVE_ROLE_TITLES:
+            role_name = EXECUTIVE_ROLE_TITLES[role.type]
             org_type = "executive"
             use_district = False
         elif role.type in ("upper", "lower", "legislature"):

--- a/openstates/utils/tests/test_to_database.py
+++ b/openstates/utils/tests/test_to_database.py
@@ -289,6 +289,34 @@ def test_person_governor_role(person):
 
 
 @pytest.mark.django_db
+def test_person_attorney_general_role(person):
+    person.roles.append(
+        Role(
+            type="attorney_general",
+            jurisdiction="ocd-jurisdiction/country:us/state:nc/government",
+            end_date="2030-01-01",
+        )
+    )
+    created, updated = load_person(person)
+    p = DjangoPerson.objects.get(pk=person.id)
+
+    assert p.memberships.count() == 2
+    assert (
+        p.memberships.get(organization__classification="executive").organization.name
+        == "Executive"
+    )
+    assert p.current_role == {
+        "org_classification": "executive",
+        "district": None,
+        "division_id": None,
+        "title": "Attorney General",
+    }
+    assert (
+        p.current_jurisdiction_id == "ocd-jurisdiction/country:us/state:nc/government"
+    )
+
+
+@pytest.mark.django_db
 def test_person_mayor_role(person):
     person.roles.append(
         Role(

--- a/openstates/utils/tests/test_to_database.py
+++ b/openstates/utils/tests/test_to_database.py
@@ -289,10 +289,20 @@ def test_person_governor_role(person):
 
 
 @pytest.mark.django_db
-def test_person_attorney_general_role(person):
+@pytest.mark.parametrize(
+    ("role_type", "title"),
+    [
+        ("lt_governor", "Lieutenant Governor"),
+        ("treasurer", "Treasurer"),
+        ("auditor", "Auditor"),
+        ("comptroller", "Comptroller"),
+        ("attorney_general", "Attorney General"),
+    ],
+)
+def test_person_new_executive_role_titles(person, role_type, title):
     person.roles.append(
         Role(
-            type="attorney_general",
+            type=role_type,
             jurisdiction="ocd-jurisdiction/country:us/state:nc/government",
             end_date="2030-01-01",
         )
@@ -309,7 +319,7 @@ def test_person_attorney_general_role(person):
         "org_classification": "executive",
         "district": None,
         "division_id": None,
-        "title": "Attorney General",
+        "title": title,
     }
     assert (
         p.current_jurisdiction_id == "ocd-jurisdiction/country:us/state:nc/government"


### PR DESCRIPTION
This unblocks executive-office imports in `openstates/people` by adding the canonical role types discussed in:
- openstates/issues#1361
- openstates/people#3417

## What changed
- add `treasurer`, `auditor`, `comptroller`, and `attorney_general` to `RoleType`
- treat those roles as executive roles for model validation
- extend `load_person` role mapping so those roles, plus existing `lt_governor`, import as executive memberships with stable display titles
- add focused tests for all four new role types and the executive title mapping path

## Why
`openstates/people#3417` introduces new executive-office records using these canonical role names, but `openstates-core` currently rejects them in the role allow-list and DB import path.

## Validation
- `python3 -m compileall openstates/models/people.py openstates/utils/people/to_database.py openstates/models/tests/test_models.py openstates/utils/tests/test_to_database.py`
- `poetry run pytest --ds=openstates.test_settings openstates/models/tests/test_models.py openstates/utils/tests/test_to_database.py`
- `openstates/models/tests/test_models.py`: passed
- `openstates/utils/tests/test_to_database.py`: blocked by local PostgreSQL auth in this shell (`password authentication failed for user \"test\"`)