### PR TITLE
Fix bug in http-resilience mode when posting data and using kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+* Fixes a syntax error that caused a bug when POSTing data in http-resilience mode, if
+  supplying headers or other kwargs.
 
 ## 6.25.0 - Apr 14, 2026
 * Adds multiple elected official role types for executive branch: treasurer, auditor,

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -415,7 +415,7 @@ class Scraper(scrapelib.Scraper):
             return super().get(url, **kwargs)
 
     def post(self, url, data=None, json=None, **kwargs):
-        request_func = lambda: super(Scraper, self).post(url, data=data, json=json**kwargs)  # noqa: E731
+        request_func = lambda: super(Scraper, self).post(url, data=data, json=json, **kwargs)  # noqa: E731
         if self.http_resilience_mode:
             return self.request_resiliently(request_func)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openstates"
-version = "6.25.0"
+version = "6.25.1"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"


### PR DESCRIPTION
I think this was just a typo that never got tested since POSTing under resilience WITH kwargs 