### PR TITLE
Validate event document URLs as URIs

### DIFF
--- a/openstates/scrape/schemas/event.py
+++ b/openstates/scrape/schemas/event.py
@@ -67,9 +67,18 @@ schema = {
             "items": {
                 "properties": {
                     "note": {"type": "string", "minLength": 1},
-                    "url": {"type": "string", "minLength": 1},
-                    "media_type": {"type": "string", "minLength": 1},
                     "date": fuzzy_date_blank,
+                    "classification": {"type": "string"},
+                    "links": {
+                        "items": {
+                            "properties": {
+                                "media_type": {"type": "string"},
+                                "url": {"type": "string", "format": "uri"},
+                            },
+                            "type": "object",
+                        },
+                        "type": "array",
+                    },
                 },
                 "type": "object",
             },

--- a/openstates/scrape/tests/test_event_scrape.py
+++ b/openstates/scrape/tests/test_event_scrape.py
@@ -125,6 +125,24 @@ def test_add_document():
     e.validate()
 
 
+def test_add_document_rejects_bad_url():
+    # Regression for openstates/issues#1298: the schema treated document
+    # urls as plain strings, so a relative path like "/whatever/124.html"
+    # silently passed validation. The url should now have to be a real URI.
+    import pytest
+
+    from openstates.exceptions import ScrapeValueError
+
+    e = event_obj()
+    e.add_document(
+        note="hello",
+        url="/whatever/124.html",
+        media_type="text/html",
+    )
+    with pytest.raises(ScrapeValueError):
+        e.validate()
+
+
 def test_participants():
     e = event_obj()
     e.add_participant("Committee of the Whole", type="committee", note="everyone")


### PR DESCRIPTION
The event documents schema (`schemas/event.py`) put `url` at the top level of each document as a plain non-empty string. That didn't match what `Event.add_document` actually writes (which is `note` + `classification` + a `links` array of `{url, media_type}`, via `_add_associated_link`), so the real url never hit the `format: uri` check and a relative path like `/whatever/124.html` silently passed validation.

Restructure the documents item schema to mirror what's already in the bill `versions_or_documents` and the event `media_schema`: a `classification` field plus a nested `links` array with uri-validated URLs. Added a regression test that asserts `e.add_document(url='/relative.html')` now fails `validate()`.

Closes openstates/issues#1298.