### PR TITLE
Stop using deprecated datetime.utcnow()

### DIFF
--- a/openstates/data/tests/conftest.py
+++ b/openstates/data/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from openstates.data.models import (
     Jurisdiction,
     Division,
@@ -90,7 +90,10 @@ def event(jurisdiction, event_location):
         jurisdiction=jurisdiction,
         description="To discuss the pros/cons of wind farming.",
         classification="committee-meeting",
-        start_date=datetime.utcnow().isoformat().split(".")[0],
+        start_date=datetime.now(timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat()
+        .split(".")[0],
         status="passed",
         location=event_location,
     )

--- a/openstates/importers/tests/test_base_importer.py
+++ b/openstates/importers/tests/test_base_importer.py
@@ -171,7 +171,9 @@ def test_invalid_fields_related_item():
 @pytest.mark.django_db
 def test_automatic_updated_at():
     create_jurisdiction()
-    difference = Organization.objects.get().updated_at - datetime.datetime.utcnow()
+    difference = Organization.objects.get().updated_at - datetime.datetime.now(
+        datetime.timezone.utc
+    ).replace(tzinfo=None)
     # updated_at should be in UTC, a bit of clock drift notwithstanding
     assert abs(difference) < datetime.timedelta(minutes=5)
 

--- a/openstates/models/common.py
+++ b/openstates/models/common.py
@@ -99,7 +99,10 @@ class TimeScoped(BaseModel):
     )
 
     def is_active(self) -> bool:
-        date = datetime.datetime.utcnow().date().isoformat()
+        # datetime.utcnow() is deprecated in Python 3.12.
+        date = (
+            datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        )
         return (self.end_date == "" or str(self.end_date) > date) and (
             self.start_date == "" or str(self.start_date) <= date
         )

--- a/openstates/scrape/tests/test_event_scrape.py
+++ b/openstates/scrape/tests/test_event_scrape.py
@@ -6,7 +6,11 @@ from openstates.scrape import Event, calculate_window
 def event_obj():
     e = Event(
         name="get-together",
-        start_date=datetime.datetime.utcnow().isoformat().split(".")[0] + "Z",
+        start_date=datetime.datetime.now(datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat()
+        .split(".")[0]
+        + "Z",
         location_name="Joe's Place",
     )
     e.add_source(url="http://example.com/foobar")


### PR DESCRIPTION
Python 3.12 deprecated `datetime.datetime.utcnow()` in favour of `datetime.datetime.now(timezone.utc)`. Swapped the four remaining call sites:

- `openstates/models/common.py` — `is_active()` does `.date().isoformat()` so no shape change
- `openstates/scrape/tests/test_event_scrape.py`, `openstates/data/tests/conftest.py`, `openstates/importers/tests/test_base_importer.py` — these compare against / feed naive consumers, so kept the naive UTC shape via `.replace(tzinfo=None)`

Skipped `openstates/cli/update.py` and `openstates/cli/people.py` for now since the values there land in places (GCS object keys, naive DateTimeField saves) where a tz suffix would change behaviour - happy to tackle those in a follow-up if you'd like.