### PR TITLE
cli: drop utcnow() from latest_bill_update / latest_people_update writes

### DIFF
--- a/openstates/cli/people.py
+++ b/openstates/cli/people.py
@@ -387,7 +387,7 @@ def load_directory_to_database(files: list[Path], purge: bool) -> None:
 
     if created_count or updated_count:
         Jurisdiction.objects.filter(id__in=updated_jurisdictions).update(
-            latest_people_update=datetime.datetime.utcnow()
+            latest_people_update=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         )
 
     click.secho(

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -303,7 +303,7 @@ def do_import(juris: State, args: argparse.Namespace) -> dict[str, typing.Any]:
             )
         )
         DatabaseJurisdiction.objects.filter(id=juris.jurisdiction_id).update(
-            latest_bill_update=datetime.datetime.utcnow()
+            latest_bill_update=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         )
 
     # compile info on all sessions that were updated in this run


### PR DESCRIPTION
Follow-up to #193. The two `utcnow()` call sites in `cli/update.py` and `cli/people.py` write to `DateTimeField`s that are saved naive, so swapping for `datetime.now(timezone.utc).replace(tzinfo=None)` keeps the on-the-wire shape identical.