### PR TITLE
Validate bill citation URLs as URIs

### DIFF
--- a/openstates/scrape/schemas/bill.py
+++ b/openstates/scrape/schemas/bill.py
@@ -162,7 +162,7 @@ schema = {
                     },
                     "effective": {"type": [fuzzy_date_blank, "null"]},
                     "expires": {"type": [fuzzy_date_blank, "null"]},
-                    "url": {"type": ["string", "null"]},
+                    "url": {"type": ["string", "null"], "format": "uri"},
                 },
                 "type": "object",
             },


### PR DESCRIPTION
Citation block's `url` field was missing the `format: uri` constraint that every other URL field in the schema already has (document, event, source). Add it so a scraper can't sneak a malformed URL into a citation.