### PR TITLE
ansistrm: narrow bare except to Exception

### DIFF
--- a/openstates/utils/ansistrm.py
+++ b/openstates/utils/ansistrm.py
@@ -62,7 +62,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except Exception:
             self.handleError(record)
 
     if os.name != "nt":


### PR DESCRIPTION
flake8 E722. The handler already re-raises `KeyboardInterrupt` and `SystemExit` above the bare `except:`, so widening to all base exceptions doesn't actually buy anything - swap for `except Exception` to make the intent explicit and silence the lint.