### PR TITLE
TimeScoped.is_active: drop deprecated utcnow

### DIFF
--- a/openstates/models/common.py
+++ b/openstates/models/common.py
@@ -99,7 +99,7 @@ class TimeScoped(BaseModel):
     )
 
     def is_active(self) -> bool:
-        date = datetime.datetime.utcnow().date().isoformat()
+        date = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
         return (self.end_date == "" or str(self.end_date) > date) and (
             self.start_date == "" or str(self.start_date) <= date
         )


### PR DESCRIPTION
`datetime.utcnow()` warns under 3.12 and is on track for removal. Since the value is only used as an ISO date for string comparison, a timezone-aware `now(timezone.utc)` works the same.