### PR TITLE
fix: resolve_person's cache key omits org_classification

### DIFF
--- a/openstates/importers/base.py
+++ b/openstates/importers/base.py
@@ -14,7 +14,9 @@ from ..exceptions import DuplicateItemError, UnresolvedIdError, DataImportError
 from ..utils import get_pseudo_id, utcnow
 from ._types import _ID, _JsonDict, _RelatedModels, _TransformerMapping
 
-_PersonCacheKey = typing.Tuple[str, typing.Optional[str], typing.Optional[str]]
+_PersonCacheKey = typing.Tuple[
+    str, typing.Optional[str], typing.Optional[str], typing.Optional[str]
+]
 
 
 def omnihash(obj: typing.Any) -> int:
@@ -575,10 +577,6 @@ class BaseImporter:
         end_date: typing.Optional[str] = None,
         org_classification: typing.Optional[str] = None,
     ) -> str:
-        cache_key = (psuedo_person_id, start_date, end_date)
-        if cache_key in self.person_cache:
-            return self.person_cache[cache_key]
-
         # turn spec into DB query
         spec = get_pseudo_id(psuedo_person_id)
 
@@ -586,6 +584,19 @@ class BaseImporter:
         if "chamber" in spec and org_classification is None:
             org_classification = spec["chamber"]
             del spec["chamber"]
+
+        # The cache key includes org_classification (resolved above, so a chamber
+        # embedded in psuedo_person_id counts the same as one passed explicitly).
+        # A bare-name lookup for one chamber and the identical lookup for a
+        # different chamber -- same name, same session dates, the normal case
+        # since a jurisdiction's chambers usually share one LegislativeSession --
+        # are different queries that can resolve to different people (e.g. two
+        # same-surname legislators, one per chamber). Without org_classification
+        # in the key, whichever chamber resolved first would silently poison the
+        # cache for the other for the rest of an import run.
+        cache_key = (psuedo_person_id, start_date, end_date, org_classification)
+        if cache_key in self.person_cache:
+            return self.person_cache[cache_key]
 
         if list(spec.keys()) == ["name"]:
             # if we're just resolving on name, include other names and family name

--- a/openstates/importers/tests/test_base_importer.py
+++ b/openstates/importers/tests/test_base_importer.py
@@ -199,6 +199,123 @@ def test_resolve_person_case_insensitive():
 
 
 @pytest.mark.django_db
+def test_resolve_person_cache_key_includes_org_classification():
+    """resolve_person()'s cache used to key only on (psuedo_person_id,
+    start_date, end_date) -- omitting org_classification. Two same-surname
+    people in different chambers of the same jurisdiction, looked up with the
+    SAME session dates (the normal case -- a jurisdiction's chambers usually
+    share one LegislativeSession), produced the SAME cache key despite being
+    genuinely different queries. Whichever chamber got resolved first within
+    an import run silently poisoned the cache for the other for the rest of
+    that run."""
+    create_jurisdiction()
+    upper_org = Organization.objects.create(jurisdiction_id="jid", classification="upper")
+    lower_org = Organization.objects.create(jurisdiction_id="jid", classification="lower")
+    upper_person = Person.objects.create(name="Smith")
+    upper_person.memberships.create(organization=upper_org)
+    lower_person = Person.objects.create(name="Smith")
+    lower_person.memberships.create(organization=lower_org)
+
+    bi = BillImporter("jid")
+    same_start, same_end = "2026-01-01", "2026-12-31"
+
+    resolved_upper = bi.resolve_person(
+        '~{"name": "Smith"}', same_start, same_end, "upper"
+    )
+    resolved_lower = bi.resolve_person(
+        '~{"name": "Smith"}', same_start, same_end, "lower"
+    )
+
+    assert resolved_upper == upper_person.id
+    assert resolved_lower == lower_person.id, (
+        "The lower-chamber lookup must resolve its own chamber's person, not "
+        "reuse the upper-chamber lookup's cached result just because the "
+        "name and session dates are identical."
+    )
+
+
+@pytest.mark.django_db
+def test_resolve_person_cache_key_includes_org_classification_reverse_order():
+    """Same shape as above, chambers queried in the opposite order -- the bug
+    doesn't care which chamber is resolved first, so neither should the fix."""
+    create_jurisdiction()
+    upper_org = Organization.objects.create(jurisdiction_id="jid", classification="upper")
+    lower_org = Organization.objects.create(jurisdiction_id="jid", classification="lower")
+    upper_person = Person.objects.create(name="Smith")
+    upper_person.memberships.create(organization=upper_org)
+    lower_person = Person.objects.create(name="Smith")
+    lower_person.memberships.create(organization=lower_org)
+
+    bi = BillImporter("jid")
+    same_start, same_end = "2026-01-01", "2026-12-31"
+
+    resolved_lower = bi.resolve_person(
+        '~{"name": "Smith"}', same_start, same_end, "lower"
+    )
+    resolved_upper = bi.resolve_person(
+        '~{"name": "Smith"}', same_start, same_end, "upper"
+    )
+
+    assert resolved_lower == lower_person.id
+    assert resolved_upper == upper_person.id
+
+
+@pytest.mark.django_db
+def test_resolve_person_cache_key_includes_embedded_chamber():
+    """The cache key is built AFTER a chamber embedded in psuedo_person_id
+    (rather than passed as the explicit org_classification argument, e.g. the
+    bill-sponsorship lookup path) is folded in -- covers that path
+    specifically. Two embedded chambers must not collide just because the
+    caller never passed org_classification explicitly."""
+    create_jurisdiction()
+    upper_org = Organization.objects.create(jurisdiction_id="jid", classification="upper")
+    lower_org = Organization.objects.create(jurisdiction_id="jid", classification="lower")
+    upper_person = Person.objects.create(name="Smith")
+    upper_person.memberships.create(organization=upper_org)
+    lower_person = Person.objects.create(name="Smith")
+    lower_person.memberships.create(organization=lower_org)
+
+    bi = BillImporter("jid")
+    same_start, same_end = "2026-01-01", "2026-12-31"
+
+    resolved_upper = bi.resolve_person(
+        '~{"name": "Smith", "chamber": "upper"}', same_start, same_end
+    )
+    resolved_lower = bi.resolve_person(
+        '~{"name": "Smith", "chamber": "lower"}', same_start, same_end
+    )
+
+    assert resolved_upper == upper_person.id
+    assert resolved_lower == lower_person.id, (
+        "A chamber embedded in psuedo_person_id must participate in the "
+        "cache key the same way an explicit org_classification does."
+    )
+
+
+@pytest.mark.django_db
+def test_resolve_person_same_chamber_still_hits_cache():
+    """The fix must not turn the cache into a no-op -- a second lookup with
+    the SAME org_classification (the common case: many votes on one bill, one
+    chamber) should still be served from cache, not re-query every time."""
+    create_jurisdiction()
+    org = Organization.objects.create(jurisdiction_id="jid", classification="lower")
+    person = Person.objects.create(name="Smith")
+    person.memberships.create(organization=org)
+
+    bi = BillImporter("jid")
+    first = bi.resolve_person('~{"name": "Smith"}', "2026-01-01", "2026-12-31", "lower")
+    cache_size_after_first = len(bi.person_cache)
+    second = bi.resolve_person('~{"name": "Smith"}', "2026-01-01", "2026-12-31", "lower")
+
+    assert first == person.id
+    assert second == person.id
+    assert len(bi.person_cache) == cache_size_after_first, (
+        "A repeat lookup with the same org_classification must hit the "
+        "existing cache entry, not add a new one."
+    )
+
+
+@pytest.mark.django_db
 def test_resolve_bill_by_date():
     j = create_jurisdiction()
     session = j.legislative_sessions.create(


### PR DESCRIPTION
## What this fixes

`BaseImporter.resolve_person()`'s cache key was `(psuedo_person_id, start_date,
end_date)` -- it did not include `org_classification` (the chamber), even
though that parameter materially changes which `Person` the query can resolve
to.

Both chambers of a bicameral jurisdiction typically share one
`LegislativeSession` (identical `start_date`/`end_date`), so a bare-name
lookup for one chamber and the identical lookup for the other chamber, within
the same import run, produce the exact same cache key. Whichever chamber gets
resolved first silently poisons the cache for the other for the rest of that
run.

Concretely: two different people who happen to share a surname, one serving
in the House and one in the Senate. A Senate vote's "Smith" lookup resolves
and caches correctly. A House vote's "Smith" lookup later in the same import
run -- same name, same session dates -- incorrectly returns the cached Senate
person instead of re-querying for the House person.

## How this was found

A real-world case: a state legislature import processing both chambers'
votes for the same session in one run hit exactly this collision for two
unrelated same-surname legislators, silently corrupting vote-attribution data
for one legislator's votes under the other's identity for months before it
was noticed (via a public-facing scorecard showing votes that turned out to
belong to someone else).

## Fix

Include `org_classification` in the cache key, computed *after* the
`psuedo_person_id`'s embedded chamber (if any) is folded into it -- so the
key always reflects the same chamber value the query itself uses, whether
that came from the explicit parameter or the embedded pseudo-id.

This is purely additive to the key's specificity: it can only make the cache
*more* precise (a hit now additionally requires `org_classification` to
match), never introduce a new false resolution the old, less-specific key
wouldn't already have risked.

## Tests

Added 4 regression tests to `test_base_importer.py`:
- Two same-surname people in different chambers, looked up with identical
  session dates in both possible orders -- each must resolve to its own
  chamber's person, not the other's cached result.
- The same collision via a chamber embedded in `psuedo_person_id` (the
  bill-sponsorship lookup path), rather than an explicit `org_classification`
  argument.
- A repeat lookup with the *same* `org_classification` (the ordinary case --
  many votes on one bill, one chamber) still hits the cache, confirming the
  fix doesn't regress into re-querying every time.

Full test suite (354 tests) passes.