### PR TITLE
fix: read CACHE_DIR and SCRAPED_DATA_DIR from env vars

### DIFF
--- a/openstates/settings.py
+++ b/openstates/settings.py
@@ -19,8 +19,8 @@ except Exception:
     verify = False
 SCRAPELIB_VERIFY = verify
 
-CACHE_DIR = os.path.join(os.getcwd(), "_cache")
-SCRAPED_DATA_DIR = os.path.join(os.getcwd(), "_data")
+CACHE_DIR = os.environ.get("CACHE_DIR", os.path.join(os.getcwd(), "_cache"))
+SCRAPED_DATA_DIR = os.environ.get("SCRAPED_DATA_DIR", os.path.join(os.getcwd(), "_data"))
 
 IMPORT_TRANSFORMERS = {
     "bill": {


### PR DESCRIPTION
## Summary

When `openstates-core` is launched via a process manager with `cwd=/` (e.g. `launchd` on macOS), `os.getcwd()` resolves to `/`, and the scraper tries to write its cache/scraped-data to `/_cache`/`/_data` -- which is a read-only filesystem in that context, so it crashes.

This lets `CACHE_DIR`/`SCRAPED_DATA_DIR` be set via environment variables, falling back to the existing `cwd`-relative default when they're not set -- so nothing changes for anyone already relying on the current behavior, but a deployment that needs an explicit, stable location (regardless of working directory at launch time) now has a way to configure it.

We've been running this fix in our own fork for a couple of months (small operational deployment scraping a handful of state legislatures) and it's been solid, so wanted to share it back in case it's useful to others running this outside a normal interactive/CI working directory.

## Test plan

- Small, self-contained change to two lines in `openstates/settings.py`, backward-compatible (env var unset -> identical behavior to today).
- Verified in our own deployment: previously crashed with a read-only-filesystem write error when launched via `launchd`; setting `CACHE_DIR`/`SCRAPED_DATA_DIR` explicitly resolved it.