### PR TITLE
Bugfix for address listings in state legislator CSVs

### DIFF
--- a/openstates/cli/people.py
+++ b/openstates/cli/people.py
@@ -205,11 +205,19 @@ def write_csv(files: list[Path], jurisdiction_id: str, output_filename: str) -> 
             district_address = district_voice = district_fax = None
             capitol_address = capitol_voice = capitol_fax = None
             for cd in person.offices:
-                if cd.classification == "district":
+                if cd.classification == "district-mail":
+                     district_address = cd.address
+                     district_voice = cd.voice
+                     district_fax = cd.fax
+                 elif cd.classification == "district":
                     district_address = cd.address
                     district_voice = cd.voice
                     district_fax = cd.fax
-                elif cd.classification == "district":
+                elif cd.classification == "capitol-mail":
+                    capitol_address = cd.address
+                    capitol_voice = cd.voice
+                    capitol_fax = cd.fax
+                elif cd.classification == "capitol":
                     capitol_address = cd.address
                     capitol_voice = cd.voice
                     capitol_fax = cd.fax


### PR DESCRIPTION
issues/1392
type:bug
component:infrastructure

- openstates/cli/people.py
    Updated the definition of the person objects from the YAML data
      to properly populate the capitol address info in the final
      objects. Previously "capitol" was typoed as "district", which
      prevented all capitol address data from being populated in
      the CSVs for all states.
    Updated the address population logic to include "capitol-mail"
      and "district-mail" if available. The new logic will populate
      "district" with "district-mail" if there is no "district"
      info (as well as for capitol/capitol-mail), as is the case for
      Alaska rep Becky Schwanke, who otherwise has no address info.
